### PR TITLE
Fixing the extendAll bug and adding a unit test for "verbose" config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.0.5
+
+- Fix _.extendAll issue where it should accept an array as a parameter
+
 ### 0.0.4
 
 - Fix default type issue

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/default.js
+++ b/src/example-types/default.js
@@ -1,3 +1,3 @@
 module.exports = {
-  validContext: x => true,
+  validContext: () => true,
 }

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -60,14 +60,14 @@ module.exports = {
           }
 
           // TODO - If nested path, iterate properties on nested path, filtering out nested path results unless mainHighlighted or relevant nested fields have b tags in them
-          return _.extendAll(
+          return _.extendAll([
             context.config.verbose ? { hit: hit } : {},
             {
               _id: hit._id,
               additionalFields: highlight ? additionalFields : [],
             },
             _.getOr(_.identity, 'elasticsearch.summaryView', schema)(hit)
-          )
+          ])
         }, results.hits.hits),
       },
     }))

--- a/test/example-types/results.js
+++ b/test/example-types/results.js
@@ -41,7 +41,7 @@ describe('results', () => {
           {
             _id: 'test-id',
             additionalFields: [],
-            field: 'test field',
+            field: 'test field'
           },
         ],
       },
@@ -79,6 +79,27 @@ describe('results', () => {
         },
       }),
     ]))
+  it('verbose should work', () => {
+    F.extendOn(context.config, { verbose: true })
+    F.extendOn(expectedResult.response.results, [
+      {
+        _id: 'test-id',
+        additionalFields: [],
+        field: 'test field',
+        hit: {
+          _id: 'test-id',
+          field: 'test field'
+        }
+      }
+    ])
+    return resultsTest(context, [
+      _.extend(expectedCalls[0], {
+        sort: {
+          _score: 'desc',
+        },
+      }),
+    ])
+  })
   it('should order by sortDir config', () => {
     F.extendOn(context.config, { sortDir: 'asc' })
     return resultsTest(context, [

--- a/test/types.js
+++ b/test/types.js
@@ -10,6 +10,7 @@ describe('All Example Types', () => {
       'cardinality',
       'date',
       'dateHistogram',
+      'default',
       'esTwoLevelAggregation',
       'exists',
       'facet',


### PR DESCRIPTION
Fix the`extendAll` bug and adding a verbose config test