### PR TITLE
Fixing extendAll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+﻿### 0.0.8
+- Our use of extendAll was wrong, it expects an array.
+
 ### 0.0.7
 - Radically reduced ascii folding checks in query example type. Recommended alternative is to use an ascii folding analyzer.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,7 @@ let ElasticsearchProvider = (
     if (aggs.aggs) request.body.size = 0
 
     // Additional config for ES searches
-    request = _.extendAll(
+    request = _.extendAll([
       {
         type: schema.elasticsearch.type,
         index: schema.elasticsearch.index,
@@ -61,7 +61,7 @@ let ElasticsearchProvider = (
         headers: options.requestorContext,
       },
       request
-    )
+    ])
     // Deterministic ordering of JSON keys for request cache optimization
     request = JSON.parse(deterministic_stringify(request))
 


### PR DESCRIPTION
Our use of extendAll was wrong, it expects an array.