### PR TITLE
Passing the headers properly with requestorContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+﻿### 0.0.10
+- Passing the headers properly with requestorContext
+
 ### 0.0.9
 - Fix request config override order
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -57,11 +57,11 @@ let ElasticsearchProvider = (
         // searchType:         context.config.searchType
       },
       config.request,
-      {
-        headers: options.requestorContext,
-      },
       request,
     ])
+
+    request.headers = _.defaults(request.headers, options.requestorContext)
+
     // Deterministic ordering of JSON keys for request cache optimization
     request = JSON.parse(deterministic_stringify(request))
 


### PR DESCRIPTION
Keeping it as it is would make the config.request headers go instead of the requestorContext if they were present.