### PR TITLE
v0.1.2, results with includes and excludes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-﻿### 0.1.1
+﻿### 0.1.2
+- Added include and exclude to the results type.
+
+### 0.1.1
 - Fixed issues with percentileRange type
 
 ### 0.1.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -24,6 +24,9 @@ module.exports = {
       },
       explain: context.config.explain,
     }
+    if (context.config.include || context.config.exclude) result._source = {}
+    if (context.config.include) result._source.includes = context.config.include
+    if (context.config.exclude) result._source.excludes = context.config.exclude
     let highlight =
       _.getOr(true, 'config.highlight', context) &&
       schema.elasticsearch.highlight

--- a/test/example-types/results.js
+++ b/test/example-types/results.js
@@ -79,8 +79,8 @@ describe('results', () => {
           includes: 'field',
         },
         sort: {
-          _score: 'desc'
-        }
+          _score: 'desc',
+        },
       }),
     ])
     delete context.config.include
@@ -93,8 +93,8 @@ describe('results', () => {
           excludes: 'field',
         },
         sort: {
-          _score: 'desc'
-        }
+          _score: 'desc',
+        },
       }),
     ])
     delete context.config.exclude

--- a/test/example-types/results.js
+++ b/test/example-types/results.js
@@ -71,6 +71,35 @@ describe('results', () => {
     ])
   })
 
+  it('should be able to filter fields with config.include', () => {
+    F.extendOn(context.config, { include: 'field' })
+    return resultsTest(context, [
+      _.extend(expectedCalls[0], {
+        _source: {
+          includes: 'field',
+        },
+        sort: {
+          _score: 'desc'
+        }
+      }),
+    ])
+    delete context.config.include
+  })
+  it('should be able to filter fields with config.exclude', () => {
+    F.extendOn(context.config, { exclude: 'field' })
+    return resultsTest(context, [
+      _.extend(expectedCalls[0], {
+        _source: {
+          excludes: 'field',
+        },
+        sort: {
+          _score: 'desc'
+        }
+      }),
+    ])
+    delete context.config.exclude
+  })
+
   it('should sort on "_score: desc" with no sortField config', () =>
     resultsTest(context, [
       _.extend(expectedCalls[0], {

--- a/test/example-types/results.js
+++ b/test/example-types/results.js
@@ -73,7 +73,7 @@ describe('results', () => {
 
   it('should be able to filter fields with config.include', () => {
     F.extendOn(context.config, { include: 'field' })
-    return resultsTest(context, [
+    resultsTest(context, [
       _.extend(expectedCalls[0], {
         _source: {
           includes: 'field',
@@ -84,10 +84,11 @@ describe('results', () => {
       }),
     ])
     delete context.config.include
+    return
   })
   it('should be able to filter fields with config.exclude', () => {
     F.extendOn(context.config, { exclude: 'field' })
-    return resultsTest(context, [
+    resultsTest(context, [
       _.extend(expectedCalls[0], {
         _source: {
           excludes: 'field',
@@ -98,6 +99,7 @@ describe('results', () => {
       }),
     ])
     delete context.config.exclude
+    return
   })
 
   it('should sort on "_score: desc" with no sortField config', () =>

--- a/test/types.js
+++ b/test/types.js
@@ -2,7 +2,8 @@ let _ = require('lodash/fp')
 let Types = require('../src/types')
 let { expect } = require('chai')
 
-describe('All Example Types', () => {
+describe('All Example Types', function () {
+  this.timeout(5000)
   it('should load', () => {
     let types = Types()
     expect(_.keys(types)).to.deep.equal([

--- a/test/types.js
+++ b/test/types.js
@@ -2,7 +2,7 @@ let _ = require('lodash/fp')
 let Types = require('../src/types')
 let { expect } = require('chai')
 
-describe('All Example Types', function () {
+describe('All Example Types', function() {
   this.timeout(5000)
   it('should load', () => {
     let types = Types()


### PR DESCRIPTION
The `results` type will now support `includes` and `excludes` to better filter the data that's received.