### PR TITLE
DateHistogram type without context.data and context.config

### DIFF
--- a/src/example-types/dateHistogram.js
+++ b/src/example-types/dateHistogram.js
@@ -5,49 +5,46 @@ let dateMath = require('@elastic/datemath')
 let esTwoLevel = require('./esTwoLevelAggregation').result
 
 module.exports = {
-  validContext: context =>
-    context.config.key_field && context.config.value_field,
+  validContext: context => context.key_field && context.value_field,
   result(context, search) {
     let payload = {
-      config: {
-        key_type: 'date_histogram',
-        key_data: {
-          interval: context.config.interval || 'year',
-          min_doc_count: 0,
-        },
-        value_type: 'stats',
-        extraAggs: [
-          {
-            key: 'max_date',
-            config: {
-              value_field: 'value',
-              data: {
-                max: {
-                  field: 'PO.IssuedDate',
-                },
-              },
-            },
-          },
-          {
-            key: 'min_date',
-            config: {
-              value_field: 'value',
-              data: {
-                min: {
-                  field: 'PO.IssuedDate',
-                },
-              },
-            },
-          },
-        ],
+      key_type: 'date_histogram',
+      key_data: {
+        interval: context.interval || 'year',
+        min_doc_count: 0,
       },
+      value_type: 'stats',
+      extraAggs: [
+        {
+          key: 'max_date',
+          config: {
+            value_field: 'value',
+            data: {
+              max: {
+                field: 'PO.IssuedDate',
+              },
+            },
+          },
+        },
+        {
+          key: 'min_date',
+          config: {
+            value_field: 'value',
+            data: {
+              min: {
+                field: 'PO.IssuedDate',
+              },
+            },
+          },
+        },
+      ],
     }
 
-    if (context.config.boundsRange_min && context.config.boundsRange_max) {
-      let useDateMath = context.config.boundsRange_useDateMath
-      let min = context.config.boundsRange_min
-      let max = context.config.boundsRange_max
-      F.extendOn(payload.config.key_data, {
+    if (context.boundsRange_min && context.boundsRange_max) {
+      let useDateMath = context.boundsRange_useDateMath
+      let min = context.boundsRange_min
+      let max = context.boundsRange_max
+      F.extendOn(payload.key_data, {
         extended_bounds: {
           min: useDateMath
             ? dateMath.parse(min)

--- a/src/example-types/esTwoLevelAggregation.js
+++ b/src/example-types/esTwoLevelAggregation.js
@@ -13,32 +13,32 @@ let F = require('futil-js')
 // }
 module.exports = {
   validContext: context =>
-    context.config.key_field &&
-    context.config.key_type &&
-    context.config.value_field &&
-    context.config.value_type,
+    context.key_field &&
+    context.key_type &&
+    context.value_field &&
+    context.value_type,
   result(context, search) {
     let query = {
       aggs: {
         twoLevelAgg: {
-          [context.config.key_type]: _.omitBy(
+          [context.key_type]: _.omitBy(
             _.isNil,
             _.extend(
               {
-                field: context.config.key_field,
+                field: context.key_field,
               },
-              context.config.key_data
+              context.key_data
             )
           ),
           aggs: {
             twoLevelAgg: {
-              [context.config.value_type]: _.omitBy(
+              [context.value_type]: _.omitBy(
                 _.isNil,
                 _.extend(
                   {
-                    field: context.config.value_field,
+                    field: context.value_field,
                   },
-                  context.config.value_data
+                  context.value_data
                 )
               ),
             },
@@ -48,14 +48,14 @@ module.exports = {
     }
     _.each(agg => {
       query.aggs[agg.key] = agg.config.data
-    }, context.config.extraAggs)
+    }, context.extraAggs)
 
-    if (context.config.filter_agg)
+    if (context.filter_agg)
       query = {
         aggs: {
           twoLevelFilter: _.extend(
             {
-              filter: context.config.filter_agg,
+              filter: context.filter_agg,
             },
             query
           ),
@@ -78,10 +78,10 @@ module.exports = {
             .twoLevelAgg.buckets
         ),
       }
-      if (context.config.extraAggs) {
+      if (context.extraAggs) {
         _.each(agg => {
           rtn[agg.key] = results.aggregations[agg.key][agg.config.value_field]
-        }, context.config.extraAggs)
+        }, context.extraAggs)
       }
       return rtn
     })

--- a/test/example-types/dateHistogram.js
+++ b/test/example-types/dateHistogram.js
@@ -48,10 +48,8 @@ describe('dateHistogram', () => {
       {
         key: 'test',
         type: 'dateHistogram',
-        config: {
-          key_field: 'PO.IssuedDate',
-          value_field: 'LineItem.TotalPrice',
-        },
+        key_field: 'PO.IssuedDate',
+        value_field: 'LineItem.TotalPrice',
       },
       {
         entries: [


### PR DESCRIPTION
Tests will fail since we're changing esTwoLevelAggregation.js, but dateHistogram tests do pass.