### PR TITLE
matchStats type without context.data and context.config

### DIFF
--- a/src/example-types/esTwoLevelAggregation.js
+++ b/src/example-types/esTwoLevelAggregation.js
@@ -13,32 +13,32 @@ let F = require('futil-js')
 // }
 module.exports = {
   validContext: context =>
-    context.config.key_field &&
-    context.config.key_type &&
-    context.config.value_field &&
-    context.config.value_type,
+    context.key_field &&
+    context.key_type &&
+    context.value_field &&
+    context.value_type,
   result(context, search) {
     let query = {
       aggs: {
         twoLevelAgg: {
-          [context.config.key_type]: _.omitBy(
+          [context.key_type]: _.omitBy(
             _.isNil,
             _.extend(
               {
-                field: context.config.key_field,
+                field: context.key_field,
               },
-              context.config.key_data
+              context.key_data
             )
           ),
           aggs: {
             twoLevelAgg: {
-              [context.config.value_type]: _.omitBy(
+              [context.value_type]: _.omitBy(
                 _.isNil,
                 _.extend(
                   {
-                    field: context.config.value_field,
+                    field: context.value_field,
                   },
-                  context.config.value_data
+                  context.value_data
                 )
               ),
             },
@@ -48,14 +48,14 @@ module.exports = {
     }
     _.each(agg => {
       query.aggs[agg.key] = agg.config.data
-    }, context.config.extraAggs)
+    }, context.extraAggs)
 
-    if (context.config.filter_agg)
+    if (context.filter_agg)
       query = {
         aggs: {
           twoLevelFilter: _.extend(
             {
-              filter: context.config.filter_agg,
+              filter: context.filter_agg,
             },
             query
           ),
@@ -78,10 +78,10 @@ module.exports = {
             .twoLevelAgg.buckets
         ),
       }
-      if (context.config.extraAggs) {
+      if (context.extraAggs) {
         _.each(agg => {
           rtn[agg.key] = results.aggregations[agg.key][agg.config.value_field]
-        }, context.config.extraAggs)
+        }, context.extraAggs)
       }
       return rtn
     })

--- a/src/example-types/matchStats.js
+++ b/src/example-types/matchStats.js
@@ -7,9 +7,7 @@ module.exports = {
     twoLevelMatch.result(
       _.merge(
         {
-          config: {
-            value_type: 'stats',
-          },
+          value_type: 'stats',
         },
         context
       ),

--- a/src/example-types/twoLevelMatch.js
+++ b/src/example-types/twoLevelMatch.js
@@ -3,33 +3,27 @@ let esTwoLevel = require('./esTwoLevelAggregation').result
 
 module.exports = {
   validContext: context =>
-    !!(
-      context.config.key_field &&
-      context.config.value_field &&
-      context.config.key_value
-    ),
+    !!(context.key_field && context.value_field && context.key_value),
   result(context, search) {
     let filter = {
-      [_.get('key_type', context.config) || 'term']: {
-        [context.config.key_field]: context.config.key_value,
+      [_.get('key_type', context) || 'term']: {
+        [context.key_field]: context.key_value,
       },
     }
     return esTwoLevel(
       _.merge(
         {
-          config: {
-            key_type: 'filters',
-            key_data: {
-              filters: {
-                pass: filter,
-                fail: {
-                  bool: {
-                    must_not: filter,
-                  },
+          key_type: 'filters',
+          key_data: {
+            filters: {
+              pass: filter,
+              fail: {
+                bool: {
+                  must_not: filter,
                 },
               },
-              field: null,
             },
+            field: null,
           },
         },
         context

--- a/test/example-types/matchStats.js
+++ b/test/example-types/matchStats.js
@@ -40,11 +40,9 @@ describe('matchStats', () => {
       {
         key: 'test',
         type: 'matchStats',
-        config: {
-          key_field: 'Vendor.City.untouched',
-          key_value: 'Washington',
-          value_field: 'LineItem.TotalPrice',
-        },
+        key_field: 'Vendor.City.untouched',
+        key_value: 'Washington',
+        value_field: 'LineItem.TotalPrice',
       },
       {
         results: [


### PR DESCRIPTION
Tests will fail because we changed esTwoLevelAggregation.js and twoLevelMatch.js