### PR TITLE
0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+﻿### 0.4.0
+* Removed the root level usage of context.data and context.config, now
+  the inner properties can be passed directly to the root object.
+
 ### 0.3.0
 * [facet, terms_stats, termsStatsHits] Add support for overriding fieldmode behavior for all terms aggregation based types. Schemas can either completely override `getField` or just `modeMap` or `rawFieldName`.
 * [facet, terms_stats, termsStatsHits] Use regexp filter intead of wildcard filter/terms include

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/test/example-types/smartIntervalHistogram.js
+++ b/test/example-types/smartIntervalHistogram.js
@@ -1,7 +1,7 @@
 let sequentialResultTest = require('./testUtils').sequentialResultTest
 
 describe('smartIntervalHistogram', () => {
-  let test = (...x) =>
+  it('should work', () =>
     sequentialResultTest(
       [
         {
@@ -40,57 +40,123 @@ describe('smartIntervalHistogram', () => {
           },
         },
       ],
-      ...x
-    )
-  it('should work', () =>
-    test(
       {
         key: 'test',
         type: 'smartIntervalHistogram',
         field: 'LineItem.TotalPrice',
       },
       {
-        interval: 250,
-        entries: [
-          {
-            key: 0,
-            count: 8587960,
+      interval: 250,
+      entries: [
+        {
+          key: 0,
+          count: 8587960,
+        },
+        {
+          key: 250,
+          count: 613556605,
+        },
+        {
+          key: 500,
+          count: 1,
+        },
+        {
+          key: 750,
+          count: 1,
+        },
+      ],
+    },
+    [
+      {
+        aggs: {
+          statistical: {
+            stats: {
+              field: 'LineItem.TotalPrice',
+            },
           },
-          {
-            key: 250,
-            count: 613556605,
-          },
-          {
-            key: 500,
-            count: 1,
-          },
-          {
-            key: 750,
-            count: 1,
-          },
-        ],
+        },
       },
+      {
+        aggs: {
+          histogram: {
+            histogram: {
+              field: 'LineItem.TotalPrice',
+              interval: 250,
+              min_doc_count: 0,
+            },
+          },
+        },
+      },
+    ]
+,
+    ))
+  it('should work with context.interval', () =>
+    sequentialResultTest(
       [
         {
-          aggs: {
-            statistical: {
-              stats: {
-                field: 'LineItem.TotalPrice',
-              },
+          aggregations: {
+            histogram: {
+              buckets: [
+                {
+                  key: 0,
+                  doc_count: 8587960,
+                },
+                {
+                  key: 250,
+                  doc_count: 613556605,
+                },
+                {
+                  key: 500,
+                  doc_count: 1,
+                },
+                {
+                  key: 750,
+                  doc_count: 1,
+                },
+              ],
             },
           },
+        }
+      ],
+      {
+        key: 'test',
+        type: 'smartIntervalHistogram',
+        field: 'LineItem.TotalPrice',
+        interval: 250,
+      },
+{
+      interval: 250,
+      entries: [
+        {
+          key: 0,
+          count: 8587960,
         },
         {
-          aggs: {
+          key: 250,
+          count: 613556605,
+        },
+        {
+          key: 500,
+          count: 1,
+        },
+        {
+          key: 750,
+          count: 1,
+        },
+      ],
+    },
+    [
+      {
+        aggs: {
+          histogram: {
             histogram: {
-              histogram: {
-                field: 'LineItem.TotalPrice',
-                interval: 250,
-                min_doc_count: 0,
-              },
+              field: 'LineItem.TotalPrice',
+              interval: 250,
+              min_doc_count: 0,
             },
           },
         },
-      ]
+      },
+    ]
     ))
 })

--- a/test/example-types/smartIntervalHistogram.js
+++ b/test/example-types/smartIntervalHistogram.js
@@ -46,49 +46,48 @@ describe('smartIntervalHistogram', () => {
         field: 'LineItem.TotalPrice',
       },
       {
-      interval: 250,
-      entries: [
+        interval: 250,
+        entries: [
+          {
+            key: 0,
+            count: 8587960,
+          },
+          {
+            key: 250,
+            count: 613556605,
+          },
+          {
+            key: 500,
+            count: 1,
+          },
+          {
+            key: 750,
+            count: 1,
+          },
+        ],
+      },
+      [
         {
-          key: 0,
-          count: 8587960,
-        },
-        {
-          key: 250,
-          count: 613556605,
-        },
-        {
-          key: 500,
-          count: 1,
-        },
-        {
-          key: 750,
-          count: 1,
-        },
-      ],
-    },
-    [
-      {
-        aggs: {
-          statistical: {
-            stats: {
-              field: 'LineItem.TotalPrice',
+          aggs: {
+            statistical: {
+              stats: {
+                field: 'LineItem.TotalPrice',
+              },
             },
           },
         },
-      },
-      {
-        aggs: {
-          histogram: {
+        {
+          aggs: {
             histogram: {
-              field: 'LineItem.TotalPrice',
-              interval: 250,
-              min_doc_count: 0,
+              histogram: {
+                field: 'LineItem.TotalPrice',
+                interval: 250,
+                min_doc_count: 0,
+              },
             },
           },
         },
-      },
-    ]
-,
+      ]
     ))
   it('should work with context.interval', () =>
     sequentialResultTest(
@@ -116,7 +115,7 @@ describe('smartIntervalHistogram', () => {
               ],
             },
           },
-        }
+        },
       ],
       {
         key: 'test',
@@ -124,39 +123,39 @@ describe('smartIntervalHistogram', () => {
         field: 'LineItem.TotalPrice',
         interval: 250,
       },
-{
-      interval: 250,
-      entries: [
-        {
-          key: 0,
-          count: 8587960,
-        },
-        {
-          key: 250,
-          count: 613556605,
-        },
-        {
-          key: 500,
-          count: 1,
-        },
-        {
-          key: 750,
-          count: 1,
-        },
-      ],
-    },
-    [
       {
-        aggs: {
-          histogram: {
+        interval: 250,
+        entries: [
+          {
+            key: 0,
+            count: 8587960,
+          },
+          {
+            key: 250,
+            count: 613556605,
+          },
+          {
+            key: 500,
+            count: 1,
+          },
+          {
+            key: 750,
+            count: 1,
+          },
+        ],
+      },
+      [
+        {
+          aggs: {
             histogram: {
-              field: 'LineItem.TotalPrice',
-              interval: 250,
-              min_doc_count: 0,
+              histogram: {
+                field: 'LineItem.TotalPrice',
+                interval: 250,
+                min_doc_count: 0,
+              },
             },
           },
         },
-      },
-    ]
+      ]
     ))
 })

--- a/test/example-types/testUtils.js
+++ b/test/example-types/testUtils.js
@@ -36,8 +36,6 @@ let sequentialResultTest = _.curry(
       _.defaults(
         {
           meta: {},
-          data: {},
-          config: {},
         },
         context
       ),


### PR DESCRIPTION
## 0.4.0
Removed the root level usage of context.data and context.config, now the inner properties can be passed directly to the root object.

Full diff: https://github.com/smartprocure/contexture-elasticsearch/compare/4870215c6ded6d2baab5a5819a132a0f2b4d4309...master

## TODOS:
- Make unit tests for smartIntervalHistogram's `interval`.