### PR TITLE
Number type no longer wraps results in a results property.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 0.6.4
+* Number type no longer wraps results in a results property.
+
 ### 0.6.3
 * Improved number type by providing a configurable interval value for the percentile aggregation.
 ### 0.6.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/number.js
+++ b/src/example-types/number.js
@@ -99,12 +99,10 @@ module.exports = {
     }
 
     return {
-      results: {
-        interval,
-        statistical,
-        histogram,
-        percentiles,
-      },
+      interval,
+      statistical,
+      histogram,
+      percentiles,
     }
   },
 }


### PR DESCRIPTION
Number type no longer wraps results in a results property.