### PR TITLE
Default size back to 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-﻿### 0.6.8
+﻿### 0.6.9
+* Facet can't allow size 0 or empty, so we're sending 10 by default (as before).
+### 0.6.8
 * Added the context property useRaw to step out of date formattings on the date example type.
 ### 0.6.7
 * Fixed Number type bug where min and max values were ignored if passed as strings.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/facet.js
+++ b/src/example-types/facet.js
@@ -43,7 +43,7 @@ module.exports = {
           terms: _.extendAll([
             {
               field,
-              size: _.isNil(context.size) ? 10 : context.size,
+              size: context.size || 10,
               order: {
                 term: { _term: 'asc' },
                 count: { _count: 'desc' },

--- a/src/example-types/facet.js
+++ b/src/example-types/facet.js
@@ -43,7 +43,7 @@ module.exports = {
           terms: _.extendAll([
             {
               field,
-              size: context.size || 10,
+              size: (context.size || context.size === 0) ? context.size : 10,
               order: {
                 term: { _term: 'asc' },
                 count: { _count: 'desc' },

--- a/src/example-types/facet.js
+++ b/src/example-types/facet.js
@@ -43,7 +43,7 @@ module.exports = {
           terms: _.extendAll([
             {
               field,
-              size: (context.size || context.size === 0) ? context.size : 10,
+              size: context.size || context.size === 0 ? context.size : 10,
               order: {
                 term: { _term: 'asc' },
                 count: { _count: 'desc' },


### PR DESCRIPTION
:) empty string or undefined was never a valid option anyway