### PR TITLE
Forcing Exclusions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-﻿### 0.7.3
+﻿### 0.8.0
 * forceExclude on the results type allows us to extend any existing exclude value (even if empty) with a default list of forceExclude fields defined at the schema.
 ### 0.7.2
 * If includeZeroes, facet should make another search for it's cardinality with query match_all.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-﻿### 0.7.2
+﻿### 0.7.3
+* forceExclude on the results type allows us to extend any existing exclude value (even if empty) with a default list of forceExclude fields defined at the schema.
+### 0.7.2
 * If includeZeroes, facet should make another search for it's cardinality with query match_all.
 ### 0.7.1
 * Using combinatorics of the received words on regexp includes if optionsFilter is present on the facet example type.

--- a/README.md
+++ b/README.md
@@ -16,12 +16,13 @@ This provider takes a config object as a parameter:
 ### Schemas
 Schemas with with an elasticsearch provider can specify any or all of the following properties:
 
-| Option        | Type       | Description                          | Required |
-| ------        | ----       | -----------                          | -------- |
-| `index`       | `string`   | Which ES index to use when querying  | x        |
-| `type`        | `string`   | Which ES type to use when querying   |          |
-| `summaryView` | `function` | Used by `results` to return a summary view instead of the whole document, (e.g. for indexes with many fields). Defaults to returning the `hit` property. | |
-| `highlight`   | `object `  | Used by `results` to determine what fields to highlight, and whether or not they are `inline` (copied over inline on to the source) or `additional` (in a list of additional fields that matched) | |
+| Option         | Type       | Description                          | Required |
+| ------         | ----       | -----------                          | -------- |
+| `index`        | `string`   | Which ES index to use when querying  | x        |
+| `type`         | `string`   | Which ES type to use when querying   |          |
+| `summaryView`  | `function` | Used by `results` to return a summary view instead of the whole document, (e.g. for indexes with many fields). Defaults to returning the `hit` property. | |
+| `highlight`    | `object`   | Used by `results` to determine what fields to highlight, and whether or not they are `inline` (copied over inline on to the source) or `additional` (in a list of additional fields that matched) | |
+| `forceExclude` | `array`    | Used by `results` to extend the exclude fields provided on the search tree. The extension happens only if the results node has a `forceExclude` flag set to true.
 
 ### Example Schema for SomeType in SomeIndex
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -24,6 +24,10 @@ module.exports = {
       },
       explain: context.explain,
     }
+
+    if (context.forceExclude && _.isArray(schema.forceExclude))
+      context.exclude = _.union(schema.forceExclude, context.exclude)
+
     if (context.include || context.exclude) result._source = {}
     if (context.include) result._source.includes = context.include
     if (context.exclude) result._source.excludes = context.exclude

--- a/test/example-types/results.js
+++ b/test/example-types/results.js
@@ -183,6 +183,21 @@ describe('results', () => {
       }),
     ])
   })
+  it('forceExclude', () => {
+    F.extendOn(context, { forceExclude: true })
+    let excludes = ['a', 'b', 'c']
+    F.extendOn(schema, { forceExclude: excludes })
+    return resultsTest(context, [
+      _.extend(expectedCalls[0], {
+        _source: {
+          excludes,
+        },
+        sort: {
+          _score: 'desc',
+        },
+      }),
+    ])
+  })
   // it.only('should populate', () => {
   //   let sortField = 'test.field'
   //   F.extendOn(context, { populate: {


### PR DESCRIPTION
forceExclude on the results type allows us to extend any existing exclude value (even if empty) with a default list of forceExclude fields defined at the schema.