### PR TITLE
Dynamic schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,97 +1,144 @@
-﻿### 0.9.1
+# 0.10.0
+* Format CHANGELOG
+* Added `getSchemas`, a utility that reads from es mappings/aliases to automatically generate schemas (complete with field definitions as well)
+* Added `exampleTypeSchemaMapping` to map es types to example contexture node types
+
+# 0.9.1
 * Use field mode for terms stats.
-### 0.9.0
+
+# 0.9.0
 * Added `tagsQuery` type.
-### 0.8.5
+
+# 0.8.5
 * Number types will now return extended instead of standard stats.
-### 0.8.4
+
+# 0.8.4
 * Number types will interpret interval min or max null values as open left or right boundaries.
-### 0.8.3
+
+# 0.8.3
 * Fix regEx for words
-﻿### 0.8.2
+
+# 0.8.2
 * Results type will now return verbose data i.e. hits property when include has items so that data values for additional fields is accessible.
-### 0.8.1
+
+# 0.8.1
 * Decomission `useRaw` in favor of `isDateTime` flag
-### 0.8.0
+
+# 0.8.0
 * forceExclude on the results type allows us to extend any existing exclude value (even if empty) with a default list of forceExclude fields defined at the schema.
-### 0.7.2
+
+# 0.7.2
 * If includeZeroes, facet should make another search for it's cardinality with query match_all.
-### 0.7.1
+
+# 0.7.1
 * Using combinatorics of the received words on regexp includes if optionsFilter is present on the facet example type.
-### 0.7.0
+
+# 0.7.0
 * Introducing new example type number range histogram.
 * Number now supports find best functionality.
 * Geo type now guards against 0 results in geocoder.
-### 0.6.9
+
+# 0.6.9
 * Facet can't allow size 0 or empty, so we're sending 10 by default (as before).
-### 0.6.8
+
+# 0.6.8
 * Added the context property useRaw to step out of date formattings on the date example type.
-### 0.6.7
+
+# 0.6.7
 * Fixed Number type bug where min and max values were ignored if passed as strings.
-### 0.6.6
+
+# 0.6.6
 * Added documentation for termsStatsHits
-### 0.6.5
+
+# 0.6.5
 * Facet now allows size 0
-### 0.6.4
+
+# 0.6.4
 * Number type no longer wraps results in a results property.
-### 0.6.3
+
+# 0.6.3
 * Improved number type by providing a configurable interval value for the percentile aggregation.
-### 0.6.2
+
+# 0.6.2
 * Improved number type by providing additional feedback as filtered range aggregations.
-### 0.6.1
+
+# 0.6.1
 * Allow min 0 and max undefined to be evaluated as truthy or vice-versa.
-### 0.6.0
+
+# 0.6.0
 * Improved number type by providing feedback as statistics and histogram results.
-### 0.5.0
+
+# 0.5.0
 * Added utility function `getSchemaMapping` to get a mapping used for building a schema directly from ES.
-### 0.4.1
+
+# 0.4.1
 * Removed the last reference of context.data from the facet type.
-### 0.4.0
+
+# 0.4.0
 * Removed the root level usage of context.data and context.config, now
   the inner properties can be passed directly to the root object.
-### 0.3.0
+
+# 0.3.0
 * [facet, terms_stats, termsStatsHits] Add support for overriding fieldmode behavior for all terms aggregation based types. Schemas can either completely override `getField` or just `modeMap` or `rawFieldName`.
 * [facet, terms_stats, termsStatsHits] Use regexp filter intead of wildcard filter/terms include
 * [terms_stats, termsStatsHits] Add support for `caseSensitive` flags for options filter
 * [terms_stats, termsStatsHits] Move off of `lowercased` and `exact`
 * [facet] Remove `anyOrder` support, now is `anyOrder` all the time (powered by bool must)
-### 0.2.2
+
+# 0.2.2
 * [Facet] Fix spacing bug on optionsFilter (regex generation)
-### 0.2.1
+
+# 0.2.1
 * [Facet] Make filtering work with includeZeroes
 * [Facet] Move off of `lowercased` and `exact`
 * [Facet] Use term `include` intead of wildcard filter
 * [Facet] Add support for `anyOrder` and `caseSensitive` flags for options filter
-### 0.2.0
+
+# 0.2.0
 * Add `includeZeroes` support to facet type.
-### 0.1.4
+
+# 0.1.4
 * Removed `__all` from .gitignore.
-### 0.1.3
+
+# 0.1.3
 * Using directory metagen instead of include-all.
-### 0.1.2
+
+# 0.1.2
 * Added include and exclude to the results type.
-### 0.1.1
+
+# 0.1.1
 * Fixed issues with percentileRange type
-### 0.1.0
+
+# 0.1.0
 * Using regexp instead of wildcard on the text type.
-### 0.0.10
+
+# 0.0.10
 * Passing the headers properly with requestorContext
-### 0.0.9
+
+# 0.0.9
 * Fix request config override order
-### 0.0.8
+
+# 0.0.8
 * Our use of extendAll was wrong, it expects an array.
-### 0.0.7
+
+# 0.0.7
 * Radically reduced ascii folding checks in query example type. Recommended alternative is to use an ascii folding analyzer.
-### 0.0.6
+
+# 0.0.6
 * Using Lodash's extend instead of the three dot syntax, so we can
   support Node v8.2.0.
-### 0.0.5
+
+# 0.0.5
 * Fix _.extendAll issue where it should accept an array as a parameter
-### 0.0.4
+
+# 0.0.4
 * Fix default type issue
-### 0.0.3
+
+# 0.0.3
 * Fix types issue
-### 0.0.2
+
+# 0.0.2
 * Add dev tooling for PRs
-### 0.0.1
+
+# 0.0.1
 * Initial release

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# contexture-elasticsearch
+# contexture-elasticsearch
 Elasticsearch Provider for Contexture
 
 ## Usage
@@ -76,6 +76,11 @@ let process = Contexture({
   }
 })
 ```
+
+## Automatic Schema Detection
+As of 0.10.0, a `getSchemas` async method is exposed on an instantiated provider, which will read the elasticsearch mappings and aliases to automatically generate schemas.
+
+Generated schemas also include field definitions, which can leveraged with something like `exampleTypeSchemaMapping` to make them fit for consumption by dynamic field pickers such as the one in contexture-react.
 
 ## Default Types
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {
-    "prepublish": "./node_modules/.bin/metagen src/example-types commonJS ./__all.js",
+    "prepublish": "./node_modules/.bin/metagen src/example-types commonJS ./__all.js --exclusions=__all.js,schemaMapping.js",
     "test": "./node_modules/mocha/bin/_mocha --recursive",
     "test-watch": "chokidar 'src/**/*.js' 'test/**/*.js' -c 'npm t'",
     "test-ci": "./node_modules/mocha/bin/_mocha --recursive --reporter json > test-results.json",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@elastic/datemath": "^2.3.0",
     "bluebird": "^3.5.0",
-    "futil-js": "^1.32.0",
+    "futil-js": "^1.49.0",
     "js-combinatorics": "^0.5.3",
     "json-stable-stringify": "^1.0.1",
     "lodash": "^4.17.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/__all.js
+++ b/src/example-types/__all.js
@@ -23,6 +23,7 @@ module.exports = {
   query: require('./query'),
   rangeStats: require('./rangeStats'),
   results: require('./results'),
+  schemaMapping: require('./schemaMapping'),
   smartIntervalHistogram: require('./smartIntervalHistogram'),
   smartPercentileRanks: require('./smartPercentileRanks'),
   statistical: require('./statistical'),

--- a/src/example-types/__all.js
+++ b/src/example-types/__all.js
@@ -1,5 +1,4 @@
 module.exports = {
-  __all: require('./__all'),
   bool: require('./bool'),
   cardinality: require('./cardinality'),
   date: require('./date'),
@@ -23,7 +22,6 @@ module.exports = {
   query: require('./query'),
   rangeStats: require('./rangeStats'),
   results: require('./results'),
-  schemaMapping: require('./schemaMapping'),
   smartIntervalHistogram: require('./smartIntervalHistogram'),
   smartPercentileRanks: require('./smartPercentileRanks'),
   statistical: require('./statistical'),
@@ -33,5 +31,5 @@ module.exports = {
   termsStatsHits: require('./termsStatsHits'),
   terms_stats: require('./terms_stats'),
   text: require('./text'),
-  twoLevelMatch: require('./twoLevelMatch'),
+  twoLevelMatch: require('./twoLevelMatch')
 }

--- a/src/example-types/__all.js
+++ b/src/example-types/__all.js
@@ -31,5 +31,5 @@ module.exports = {
   termsStatsHits: require('./termsStatsHits'),
   terms_stats: require('./terms_stats'),
   text: require('./text'),
-  twoLevelMatch: require('./twoLevelMatch')
+  twoLevelMatch: require('./twoLevelMatch'),
 }

--- a/src/example-types/schemaMapping.js
+++ b/src/example-types/schemaMapping.js
@@ -16,11 +16,13 @@ let addNodeType = x => {
     typeOptions: {
       text: ['facet', 'query'],
     }[type] || [typeDefault],
-    ...x
+    ...x,
   }
 }
-let exampleTypeSchemaMapping = _.mapValues(_.update('fields', _.mapValues(addNodeType)))
+let exampleTypeSchemaMapping = _.mapValues(
+  _.update('fields', _.mapValues(addNodeType))
+)
 
 module.exports = {
-  exampleTypeSchemaMapping
+  exampleTypeSchemaMapping,
 }

--- a/src/example-types/schemaMapping.js
+++ b/src/example-types/schemaMapping.js
@@ -1,0 +1,26 @@
+let _ = require('lodash/fp')
+let F = require('futil-js')
+
+let addNodeType = x => {
+  let type = x.elasticsearch.dataType
+  let typeDefault = F.alias(type, {
+    string: 'query',
+    text: 'facet',
+    long: 'number',
+    float: 'number',
+    double: 'number',
+  })
+  return {
+    typeDefault,
+    // TODO: exists, bool, geo, text
+    typeOptions: {
+      text: ['facet', 'query'],
+    }[type] || [typeDefault],
+    ...x
+  }
+}
+let exampleTypeSchemaMapping = _.mapValues(_.update('fields', _.mapValues(addNodeType)))
+
+module.exports = {
+  exampleTypeSchemaMapping
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 let _ = require('lodash/fp')
 let Promise = require('bluebird')
 let deterministic_stringify = require('json-stable-stringify')
-let {getESSchemas} = require('./schema')
+let { getESSchemas } = require('./schema')
 
 let ElasticsearchProvider = (
   config = {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 let _ = require('lodash/fp')
 let Promise = require('bluebird')
 let deterministic_stringify = require('json-stable-stringify')
+let {getESSchemas} = require('./schema')
 
 let ElasticsearchProvider = (
   config = {
@@ -101,6 +102,7 @@ let ElasticsearchProvider = (
       return _.get([key, 'mappings', type, 'properties'], mapping)
     }
   },
+  getSchemas: () => getESSchemas(config.getClient()),
 })
 
 module.exports = ElasticsearchProvider

--- a/src/schema.js
+++ b/src/schema.js
@@ -32,16 +32,16 @@ let fromEsIndexMapping = _.mapValues(
     _.omit(['_default_']),
     _.toPairs,
     // Capture esType
-    ([[type, fields]]) => ({fields, elasticsearch: {type}}),
+    ([[type, fields]]) => ({ fields, elasticsearch: { type } }),
     _.update(
       'fields',
       _.flow(
         flatten,
-        _.mapValues(({type, fields}) => ({
+        _.mapValues(({ type, fields }) => ({
           elasticsearch: F.compactObject({
             dataType: type,
             // Find the child notAnalyzedField to set up facet autocomplete vs word
-            notAnalyzedField: _.findKey({type: 'keyword'}, fields),
+            notAnalyzedField: _.findKey({ type: 'keyword' }, fields),
           }),
         })),
         applyDefaults
@@ -72,16 +72,16 @@ let fromMappingsWithAliases = (mappings, aliases) => {
     F.invertByArray,
     _.mapValues(([x]) => schemas[x]),
     _.merge(schemas),
-    F.mapValuesIndexed((val, index) => _.merge({elasticsearch: {index}}, val))
+    F.mapValuesIndexed((val, index) =>
+      _.merge({ elasticsearch: { index } }, val)
+    )
   )(aliases)
 }
-
 
 let getESSchemas = client =>
   Promise.all([client.indices.getMapping(), client.indices.getAlias()]).then(
     ([mappings, aliases]) => fromMappingsWithAliases(mappings, aliases)
   )
-  
 
 module.exports = {
   // flagFields,

--- a/src/schema.js
+++ b/src/schema.js
@@ -61,13 +61,20 @@ let fromEsIndexMapping = _.mapValues(
   )
 )
 
+let copySchemasToAliases = schemas =>
+  _.flow(
+    _.mapValues(x => _.keys(x.aliases)),
+    F.invertByArray,
+    // Just takes the first index that matched the alias
+    _.mapValues(([x]) => schemas[x])
+  )
+
 let fromMappingsWithAliases = (mappings, aliases) => {
   let schemas = fromEsIndexMapping(mappings)
   return _.flow(
-    _.mapValues(x => _.keys(x.aliases)),
-    F.invertByArray,
-    _.mapValues(([x]) => schemas[x]),
+    copySchemasToAliases(schemas),
     _.merge(schemas),
+    // Apply indexes at the end so aliases don't get indexes for the non aliased mappings
     F.mapValuesIndexed((val, index) =>
       _.merge({ elasticsearch: { index } }, val)
     )

--- a/src/schema.js
+++ b/src/schema.js
@@ -1,10 +1,6 @@
 let _ = require('lodash/fp')
 let F = require('futil-js')
 
-let flagFields = _.flow(
-  F.invertByArray,
-  _.mapValues(F.flags)
-)
 let applyDefaults = F.mapValuesIndexed((node, field) =>
   _.defaults(
     {

--- a/src/schema.js
+++ b/src/schema.js
@@ -1,0 +1,92 @@
+let _ = require('lodash/fp')
+let F = require('futil-js')
+
+let flagFields = _.flow(
+  F.invertByArray,
+  _.mapValues(F.flags)
+)
+let applyDefaults = F.mapValuesIndexed((node, field) =>
+  _.defaults(
+    {
+      field,
+      label: F.autoLabel(field),
+      order: 0,
+    },
+    node
+  )
+)
+
+let firstValue = _.curry((field, data) => _.get(field, _.find(field, data)))
+
+let Tree = F.tree(x => x.properties)
+// flatLeaves should auto detect reject vs omit (or just more general obj vs arr method)
+let flatten = _.flow(
+  Tree.flatten(),
+  _.omitBy(Tree.traverse)
+)
+
+let fromEsIndexMapping = _.mapValues(
+  _.flow(
+    _.get('mappings'),
+    // Always 1 type per index but sometimes there's a `_default_` type thing
+    _.omit(['_default_']),
+    _.toPairs,
+    // Capture esType
+    ([[type, fields]]) => ({fields, elasticsearch: {type}}),
+    _.update(
+      'fields',
+      _.flow(
+        flatten,
+        _.mapValues(({type, fields}) => ({
+          elasticsearch: F.compactObject({
+            dataType: type,
+            // Find the child notAnalyzedField to set up facet autocomplete vs word
+            notAnalyzedField: _.findKey({type: 'keyword'}, fields),
+          }),
+        })),
+        applyDefaults
+      )
+    ),
+    // TODO: Add contexture-elasticsearch support for per field notAnalyzedField
+    // In the mean time, this will set the subfields used by things like facet autpcomplete for each index as a whole
+    schema =>
+      _.extend(
+        {
+          modeMap: {
+            word: '',
+            autocomplete: `.${firstValue(
+              'elasticsearch.notAnalyzedField',
+              schema.fields
+            )}`,
+          },
+        },
+        schema
+      )
+  )
+)
+
+let fromMappingsWithAliases = (mappings, aliases) => {
+  let schemas = fromEsIndexMapping(mappings)
+  return _.flow(
+    _.mapValues(x => _.keys(x.aliases)),
+    F.invertByArray,
+    _.mapValues(([x]) => schemas[x]),
+    _.merge(schemas),
+    F.mapValuesIndexed((val, index) => _.merge({elasticsearch: {index}}, val))
+  )(aliases)
+}
+
+
+let getESSchemas = client =>
+  Promise.all([client.indices.getMapping(), client.indices.getAlias()]).then(
+    ([mappings, aliases]) => fromMappingsWithAliases(mappings, aliases)
+  )
+  
+
+module.exports = {
+  // flagFields,
+  // applyDefaults,
+  // fromEsIndexMapping,
+  fromMappingsWithAliases,
+  getESSchemas,
+}

--- a/test/schema-data/imdb-aliases.js
+++ b/test/schema-data/imdb-aliases.js
@@ -1,7 +1,7 @@
 module.exports = {
-  "movies": {
-    "aliases": {
-      "imdb": {}
-    }
-  }
+  movies: {
+    aliases: {
+      imdb: {},
+    },
+  },
 }

--- a/test/schema-data/imdb-aliases.js
+++ b/test/schema-data/imdb-aliases.js
@@ -1,0 +1,7 @@
+module.exports = {
+  "movies": {
+    "aliases": {
+      "imdb": {}
+    }
+  }
+}

--- a/test/schema-data/imdb-mapping.js
+++ b/test/schema-data/imdb-mapping.js
@@ -1,148 +1,148 @@
 module.exports = {
-  "movies": {
-    "mappings": {
-      "movie": {
-        "properties": {
-          "actors": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+  movies: {
+    mappings: {
+      movie: {
+        properties: {
+          actors: {
+            type: 'text',
+            fields: {
+              keyword: {
+                type: 'keyword',
+                ignore_above: 256,
+              },
+            },
           },
-          "awards": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+          awards: {
+            type: 'text',
+            fields: {
+              keyword: {
+                type: 'keyword',
+                ignore_above: 256,
+              },
+            },
           },
-          "countries": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+          countries: {
+            type: 'text',
+            fields: {
+              keyword: {
+                type: 'keyword',
+                ignore_above: 256,
+              },
+            },
           },
-          "directors": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+          directors: {
+            type: 'text',
+            fields: {
+              keyword: {
+                type: 'keyword',
+                ignore_above: 256,
+              },
+            },
           },
-          "genres": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+          genres: {
+            type: 'text',
+            fields: {
+              keyword: {
+                type: 'keyword',
+                ignore_above: 256,
+              },
+            },
           },
-          "imdbId": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+          imdbId: {
+            type: 'text',
+            fields: {
+              keyword: {
+                type: 'keyword',
+                ignore_above: 256,
+              },
+            },
           },
-          "imdbRating": {
-            "type": "float"
+          imdbRating: {
+            type: 'float',
           },
-          "imdbVotes": {
-            "type": "long"
+          imdbVotes: {
+            type: 'long',
           },
-          "languages": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+          languages: {
+            type: 'text',
+            fields: {
+              keyword: {
+                type: 'keyword',
+                ignore_above: 256,
+              },
+            },
           },
-          "metaScore": {
-            "type": "long"
+          metaScore: {
+            type: 'long',
           },
-          "plot": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+          plot: {
+            type: 'text',
+            fields: {
+              keyword: {
+                type: 'keyword',
+                ignore_above: 256,
+              },
+            },
           },
-          "poster": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+          poster: {
+            type: 'text',
+            fields: {
+              keyword: {
+                type: 'keyword',
+                ignore_above: 256,
+              },
+            },
           },
-          "rated": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+          rated: {
+            type: 'text',
+            fields: {
+              keyword: {
+                type: 'keyword',
+                ignore_above: 256,
+              },
+            },
           },
-          "released": {
-            "type": "date"
+          released: {
+            type: 'date',
           },
-          "runtimeMinutes": {
-            "type": "long"
+          runtimeMinutes: {
+            type: 'long',
           },
-          "title": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+          title: {
+            type: 'text',
+            fields: {
+              keyword: {
+                type: 'keyword',
+                ignore_above: 256,
+              },
+            },
           },
-          "type": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+          type: {
+            type: 'text',
+            fields: {
+              keyword: {
+                type: 'keyword',
+                ignore_above: 256,
+              },
+            },
           },
-          "writers": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+          writers: {
+            type: 'text',
+            fields: {
+              keyword: {
+                type: 'keyword',
+                ignore_above: 256,
+              },
+            },
           },
-          "year": {
-            "type": "long"
+          year: {
+            type: 'long',
           },
-          "yearEnded": {
-            "type": "long"
-          }
-        }
-      }
-    }
-  }
+          yearEnded: {
+            type: 'long',
+          },
+        },
+      },
+    },
+  },
 }

--- a/test/schema-data/imdb-mapping.js
+++ b/test/schema-data/imdb-mapping.js
@@ -1,0 +1,148 @@
+module.exports = {
+  "movies": {
+    "mappings": {
+      "movie": {
+        "properties": {
+          "actors": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          },
+          "awards": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          },
+          "countries": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          },
+          "directors": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          },
+          "genres": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          },
+          "imdbId": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          },
+          "imdbRating": {
+            "type": "float"
+          },
+          "imdbVotes": {
+            "type": "long"
+          },
+          "languages": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          },
+          "metaScore": {
+            "type": "long"
+          },
+          "plot": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          },
+          "poster": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          },
+          "rated": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          },
+          "released": {
+            "type": "date"
+          },
+          "runtimeMinutes": {
+            "type": "long"
+          },
+          "title": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          },
+          "type": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          },
+          "writers": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          },
+          "year": {
+            "type": "long"
+          },
+          "yearEnded": {
+            "type": "long"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/schema-data/imdb-schema.js
+++ b/test/schema-data/imdb-schema.js
@@ -1,452 +1,452 @@
 module.exports = {
-  "movies": {
-    "elasticsearch": {
-      "index": "movies",
-      "type": "movie"
+  movies: {
+    elasticsearch: {
+      index: 'movies',
+      type: 'movie',
     },
-    "modeMap": {
-      "word": "",
-      "autocomplete": ".keyword"
+    modeMap: {
+      word: '',
+      autocomplete: '.keyword',
     },
-    "fields": {
-      "actors": {
-        "typeDefault": "facet",
-        "typeOptions": ["facet", "query"],
-        "elasticsearch": {
-          "dataType": "text",
-          "notAnalyzedField": "keyword"
+    fields: {
+      actors: {
+        typeDefault: 'facet',
+        typeOptions: ['facet', 'query'],
+        elasticsearch: {
+          dataType: 'text',
+          notAnalyzedField: 'keyword',
         },
-        "field": "actors",
-        "label": "Actors",
-        "order": 0
+        field: 'actors',
+        label: 'Actors',
+        order: 0,
       },
-      "awards": {
-        "typeDefault": "facet",
-        "typeOptions": ["facet", "query"],
-        "elasticsearch": {
-          "dataType": "text",
-          "notAnalyzedField": "keyword"
+      awards: {
+        typeDefault: 'facet',
+        typeOptions: ['facet', 'query'],
+        elasticsearch: {
+          dataType: 'text',
+          notAnalyzedField: 'keyword',
         },
-        "field": "awards",
-        "label": "Awards",
-        "order": 0
+        field: 'awards',
+        label: 'Awards',
+        order: 0,
       },
-      "countries": {
-        "typeDefault": "facet",
-        "typeOptions": ["facet", "query"],
-        "elasticsearch": {
-          "dataType": "text",
-          "notAnalyzedField": "keyword"
+      countries: {
+        typeDefault: 'facet',
+        typeOptions: ['facet', 'query'],
+        elasticsearch: {
+          dataType: 'text',
+          notAnalyzedField: 'keyword',
         },
-        "field": "countries",
-        "label": "Countries",
-        "order": 0
+        field: 'countries',
+        label: 'Countries',
+        order: 0,
       },
-      "directors": {
-        "typeDefault": "facet",
-        "typeOptions": ["facet", "query"],
-        "elasticsearch": {
-          "dataType": "text",
-          "notAnalyzedField": "keyword"
+      directors: {
+        typeDefault: 'facet',
+        typeOptions: ['facet', 'query'],
+        elasticsearch: {
+          dataType: 'text',
+          notAnalyzedField: 'keyword',
         },
-        "field": "directors",
-        "label": "Directors",
-        "order": 0
+        field: 'directors',
+        label: 'Directors',
+        order: 0,
       },
-      "genres": {
-        "typeDefault": "facet",
-        "typeOptions": ["facet", "query"],
-        "elasticsearch": {
-          "dataType": "text",
-          "notAnalyzedField": "keyword"
+      genres: {
+        typeDefault: 'facet',
+        typeOptions: ['facet', 'query'],
+        elasticsearch: {
+          dataType: 'text',
+          notAnalyzedField: 'keyword',
         },
-        "field": "genres",
-        "label": "Genres",
-        "order": 0
+        field: 'genres',
+        label: 'Genres',
+        order: 0,
       },
-      "imdbId": {
-        "typeDefault": "facet",
-        "typeOptions": ["facet", "query"],
-        "elasticsearch": {
-          "dataType": "text",
-          "notAnalyzedField": "keyword"
+      imdbId: {
+        typeDefault: 'facet',
+        typeOptions: ['facet', 'query'],
+        elasticsearch: {
+          dataType: 'text',
+          notAnalyzedField: 'keyword',
         },
-        "field": "imdbId",
-        "label": "Imdb Id",
-        "order": 0
+        field: 'imdbId',
+        label: 'Imdb Id',
+        order: 0,
       },
-      "imdbRating": {
-        "typeDefault": "number",
-        "typeOptions": ["number"],
-        "elasticsearch": {
-          "dataType": "float"
+      imdbRating: {
+        typeDefault: 'number',
+        typeOptions: ['number'],
+        elasticsearch: {
+          dataType: 'float',
         },
-        "field": "imdbRating",
-        "label": "Imdb Rating",
-        "order": 0
+        field: 'imdbRating',
+        label: 'Imdb Rating',
+        order: 0,
       },
-      "imdbVotes": {
-        "typeDefault": "number",
-        "typeOptions": ["number"],
-        "elasticsearch": {
-          "dataType": "long"
+      imdbVotes: {
+        typeDefault: 'number',
+        typeOptions: ['number'],
+        elasticsearch: {
+          dataType: 'long',
         },
-        "field": "imdbVotes",
-        "label": "Imdb Votes",
-        "order": 0
+        field: 'imdbVotes',
+        label: 'Imdb Votes',
+        order: 0,
       },
-      "languages": {
-        "typeDefault": "facet",
-        "typeOptions": ["facet", "query"],
-        "elasticsearch": {
-          "dataType": "text",
-          "notAnalyzedField": "keyword"
+      languages: {
+        typeDefault: 'facet',
+        typeOptions: ['facet', 'query'],
+        elasticsearch: {
+          dataType: 'text',
+          notAnalyzedField: 'keyword',
         },
-        "field": "languages",
-        "label": "Languages",
-        "order": 0
+        field: 'languages',
+        label: 'Languages',
+        order: 0,
       },
-      "metaScore": {
-        "typeDefault": "number",
-        "typeOptions": ["number"],
-        "elasticsearch": {
-          "dataType": "long"
+      metaScore: {
+        typeDefault: 'number',
+        typeOptions: ['number'],
+        elasticsearch: {
+          dataType: 'long',
         },
-        "field": "metaScore",
-        "label": "Meta Score",
-        "order": 0
+        field: 'metaScore',
+        label: 'Meta Score',
+        order: 0,
       },
-      "plot": {
-        "typeDefault": "facet",
-        "typeOptions": ["facet", "query"],
-        "elasticsearch": {
-          "dataType": "text",
-          "notAnalyzedField": "keyword"
+      plot: {
+        typeDefault: 'facet',
+        typeOptions: ['facet', 'query'],
+        elasticsearch: {
+          dataType: 'text',
+          notAnalyzedField: 'keyword',
         },
-        "field": "plot",
-        "label": "Plot",
-        "order": 0
+        field: 'plot',
+        label: 'Plot',
+        order: 0,
       },
-      "poster": {
-        "typeDefault": "facet",
-        "typeOptions": ["facet", "query"],
-        "elasticsearch": {
-          "dataType": "text",
-          "notAnalyzedField": "keyword"
+      poster: {
+        typeDefault: 'facet',
+        typeOptions: ['facet', 'query'],
+        elasticsearch: {
+          dataType: 'text',
+          notAnalyzedField: 'keyword',
         },
-        "field": "poster",
-        "label": "Poster",
-        "order": 0
+        field: 'poster',
+        label: 'Poster',
+        order: 0,
       },
-      "rated": {
-        "typeDefault": "facet",
-        "typeOptions": ["facet", "query"],
-        "elasticsearch": {
-          "dataType": "text",
-          "notAnalyzedField": "keyword"
+      rated: {
+        typeDefault: 'facet',
+        typeOptions: ['facet', 'query'],
+        elasticsearch: {
+          dataType: 'text',
+          notAnalyzedField: 'keyword',
         },
-        "field": "rated",
-        "label": "Rated",
-        "order": 0
+        field: 'rated',
+        label: 'Rated',
+        order: 0,
       },
-      "released": {
-        "typeDefault": "date",
-        "typeOptions": ["date"],
-        "elasticsearch": {
-          "dataType": "date"
+      released: {
+        typeDefault: 'date',
+        typeOptions: ['date'],
+        elasticsearch: {
+          dataType: 'date',
         },
-        "field": "released",
-        "label": "Released",
-        "order": 0
+        field: 'released',
+        label: 'Released',
+        order: 0,
       },
-      "runtimeMinutes": {
-        "typeDefault": "number",
-        "typeOptions": ["number"],
-        "elasticsearch": {
-          "dataType": "long"
+      runtimeMinutes: {
+        typeDefault: 'number',
+        typeOptions: ['number'],
+        elasticsearch: {
+          dataType: 'long',
         },
-        "field": "runtimeMinutes",
-        "label": "Runtime Minutes",
-        "order": 0
+        field: 'runtimeMinutes',
+        label: 'Runtime Minutes',
+        order: 0,
       },
-      "title": {
-        "typeDefault": "facet",
-        "typeOptions": ["facet", "query"],
-        "elasticsearch": {
-          "dataType": "text",
-          "notAnalyzedField": "keyword"
+      title: {
+        typeDefault: 'facet',
+        typeOptions: ['facet', 'query'],
+        elasticsearch: {
+          dataType: 'text',
+          notAnalyzedField: 'keyword',
         },
-        "field": "title",
-        "label": "Title",
-        "order": 0
+        field: 'title',
+        label: 'Title',
+        order: 0,
       },
-      "type": {
-        "typeDefault": "facet",
-        "typeOptions": ["facet", "query"],
-        "elasticsearch": {
-          "dataType": "text",
-          "notAnalyzedField": "keyword"
+      type: {
+        typeDefault: 'facet',
+        typeOptions: ['facet', 'query'],
+        elasticsearch: {
+          dataType: 'text',
+          notAnalyzedField: 'keyword',
         },
-        "field": "type",
-        "label": "Type",
-        "order": 0
+        field: 'type',
+        label: 'Type',
+        order: 0,
       },
-      "writers": {
-        "typeDefault": "facet",
-        "typeOptions": ["facet", "query"],
-        "elasticsearch": {
-          "dataType": "text",
-          "notAnalyzedField": "keyword"
+      writers: {
+        typeDefault: 'facet',
+        typeOptions: ['facet', 'query'],
+        elasticsearch: {
+          dataType: 'text',
+          notAnalyzedField: 'keyword',
         },
-        "field": "writers",
-        "label": "Writers",
-        "order": 0
+        field: 'writers',
+        label: 'Writers',
+        order: 0,
       },
-      "year": {
-        "typeDefault": "number",
-        "typeOptions": ["number"],
-        "elasticsearch": {
-          "dataType": "long"
+      year: {
+        typeDefault: 'number',
+        typeOptions: ['number'],
+        elasticsearch: {
+          dataType: 'long',
         },
-        "field": "year",
-        "label": "Year",
-        "order": 0
+        field: 'year',
+        label: 'Year',
+        order: 0,
       },
-      "yearEnded": {
-        "typeDefault": "number",
-        "typeOptions": ["number"],
-        "elasticsearch": {
-          "dataType": "long"
+      yearEnded: {
+        typeDefault: 'number',
+        typeOptions: ['number'],
+        elasticsearch: {
+          dataType: 'long',
         },
-        "field": "yearEnded",
-        "label": "Year Ended",
-        "order": 0
-      }
-    }
+        field: 'yearEnded',
+        label: 'Year Ended',
+        order: 0,
+      },
+    },
   },
-  "imdb": {
-    "elasticsearch": {
-      "index": "imdb",
-      "type": "movie"
+  imdb: {
+    elasticsearch: {
+      index: 'imdb',
+      type: 'movie',
     },
-    "modeMap": {
-      "word": "",
-      "autocomplete": ".keyword"
+    modeMap: {
+      word: '',
+      autocomplete: '.keyword',
     },
-    "fields": {
-      "actors": {
-        "typeDefault": "facet",
-        "typeOptions": ["facet", "query"],
-        "elasticsearch": {
-          "dataType": "text",
-          "notAnalyzedField": "keyword"
+    fields: {
+      actors: {
+        typeDefault: 'facet',
+        typeOptions: ['facet', 'query'],
+        elasticsearch: {
+          dataType: 'text',
+          notAnalyzedField: 'keyword',
         },
-        "field": "actors",
-        "label": "Actors",
-        "order": 0
+        field: 'actors',
+        label: 'Actors',
+        order: 0,
       },
-      "awards": {
-        "typeDefault": "facet",
-        "typeOptions": ["facet", "query"],
-        "elasticsearch": {
-          "dataType": "text",
-          "notAnalyzedField": "keyword"
+      awards: {
+        typeDefault: 'facet',
+        typeOptions: ['facet', 'query'],
+        elasticsearch: {
+          dataType: 'text',
+          notAnalyzedField: 'keyword',
         },
-        "field": "awards",
-        "label": "Awards",
-        "order": 0
+        field: 'awards',
+        label: 'Awards',
+        order: 0,
       },
-      "countries": {
-        "typeDefault": "facet",
-        "typeOptions": ["facet", "query"],
-        "elasticsearch": {
-          "dataType": "text",
-          "notAnalyzedField": "keyword"
+      countries: {
+        typeDefault: 'facet',
+        typeOptions: ['facet', 'query'],
+        elasticsearch: {
+          dataType: 'text',
+          notAnalyzedField: 'keyword',
         },
-        "field": "countries",
-        "label": "Countries",
-        "order": 0
+        field: 'countries',
+        label: 'Countries',
+        order: 0,
       },
-      "directors": {
-        "typeDefault": "facet",
-        "typeOptions": ["facet", "query"],
-        "elasticsearch": {
-          "dataType": "text",
-          "notAnalyzedField": "keyword"
+      directors: {
+        typeDefault: 'facet',
+        typeOptions: ['facet', 'query'],
+        elasticsearch: {
+          dataType: 'text',
+          notAnalyzedField: 'keyword',
         },
-        "field": "directors",
-        "label": "Directors",
-        "order": 0
+        field: 'directors',
+        label: 'Directors',
+        order: 0,
       },
-      "genres": {
-        "typeDefault": "facet",
-        "typeOptions": ["facet", "query"],
-        "elasticsearch": {
-          "dataType": "text",
-          "notAnalyzedField": "keyword"
+      genres: {
+        typeDefault: 'facet',
+        typeOptions: ['facet', 'query'],
+        elasticsearch: {
+          dataType: 'text',
+          notAnalyzedField: 'keyword',
         },
-        "field": "genres",
-        "label": "Genres",
-        "order": 0
+        field: 'genres',
+        label: 'Genres',
+        order: 0,
       },
-      "imdbId": {
-        "typeDefault": "facet",
-        "typeOptions": ["facet", "query"],
-        "elasticsearch": {
-          "dataType": "text",
-          "notAnalyzedField": "keyword"
+      imdbId: {
+        typeDefault: 'facet',
+        typeOptions: ['facet', 'query'],
+        elasticsearch: {
+          dataType: 'text',
+          notAnalyzedField: 'keyword',
         },
-        "field": "imdbId",
-        "label": "Imdb Id",
-        "order": 0
+        field: 'imdbId',
+        label: 'Imdb Id',
+        order: 0,
       },
-      "imdbRating": {
-        "typeDefault": "number",
-        "typeOptions": ["number"],
-        "elasticsearch": {
-          "dataType": "float"
+      imdbRating: {
+        typeDefault: 'number',
+        typeOptions: ['number'],
+        elasticsearch: {
+          dataType: 'float',
         },
-        "field": "imdbRating",
-        "label": "Imdb Rating",
-        "order": 0
+        field: 'imdbRating',
+        label: 'Imdb Rating',
+        order: 0,
       },
-      "imdbVotes": {
-        "typeDefault": "number",
-        "typeOptions": ["number"],
-        "elasticsearch": {
-          "dataType": "long"
+      imdbVotes: {
+        typeDefault: 'number',
+        typeOptions: ['number'],
+        elasticsearch: {
+          dataType: 'long',
         },
-        "field": "imdbVotes",
-        "label": "Imdb Votes",
-        "order": 0
+        field: 'imdbVotes',
+        label: 'Imdb Votes',
+        order: 0,
       },
-      "languages": {
-        "typeDefault": "facet",
-        "typeOptions": ["facet", "query"],
-        "elasticsearch": {
-          "dataType": "text",
-          "notAnalyzedField": "keyword"
+      languages: {
+        typeDefault: 'facet',
+        typeOptions: ['facet', 'query'],
+        elasticsearch: {
+          dataType: 'text',
+          notAnalyzedField: 'keyword',
         },
-        "field": "languages",
-        "label": "Languages",
-        "order": 0
+        field: 'languages',
+        label: 'Languages',
+        order: 0,
       },
-      "metaScore": {
-        "typeDefault": "number",
-        "typeOptions": ["number"],
-        "elasticsearch": {
-          "dataType": "long"
+      metaScore: {
+        typeDefault: 'number',
+        typeOptions: ['number'],
+        elasticsearch: {
+          dataType: 'long',
         },
-        "field": "metaScore",
-        "label": "Meta Score",
-        "order": 0
+        field: 'metaScore',
+        label: 'Meta Score',
+        order: 0,
       },
-      "plot": {
-        "typeDefault": "facet",
-        "typeOptions": ["facet", "query"],
-        "elasticsearch": {
-          "dataType": "text",
-          "notAnalyzedField": "keyword"
+      plot: {
+        typeDefault: 'facet',
+        typeOptions: ['facet', 'query'],
+        elasticsearch: {
+          dataType: 'text',
+          notAnalyzedField: 'keyword',
         },
-        "field": "plot",
-        "label": "Plot",
-        "order": 0
+        field: 'plot',
+        label: 'Plot',
+        order: 0,
       },
-      "poster": {
-        "typeDefault": "facet",
-        "typeOptions": ["facet", "query"],
-        "elasticsearch": {
-          "dataType": "text",
-          "notAnalyzedField": "keyword"
+      poster: {
+        typeDefault: 'facet',
+        typeOptions: ['facet', 'query'],
+        elasticsearch: {
+          dataType: 'text',
+          notAnalyzedField: 'keyword',
         },
-        "field": "poster",
-        "label": "Poster",
-        "order": 0
+        field: 'poster',
+        label: 'Poster',
+        order: 0,
       },
-      "rated": {
-        "typeDefault": "facet",
-        "typeOptions": ["facet", "query"],
-        "elasticsearch": {
-          "dataType": "text",
-          "notAnalyzedField": "keyword"
+      rated: {
+        typeDefault: 'facet',
+        typeOptions: ['facet', 'query'],
+        elasticsearch: {
+          dataType: 'text',
+          notAnalyzedField: 'keyword',
         },
-        "field": "rated",
-        "label": "Rated",
-        "order": 0
+        field: 'rated',
+        label: 'Rated',
+        order: 0,
       },
-      "released": {
-        "typeDefault": "date",
-        "typeOptions": ["date"],
-        "elasticsearch": {
-          "dataType": "date"
+      released: {
+        typeDefault: 'date',
+        typeOptions: ['date'],
+        elasticsearch: {
+          dataType: 'date',
         },
-        "field": "released",
-        "label": "Released",
-        "order": 0
+        field: 'released',
+        label: 'Released',
+        order: 0,
       },
-      "runtimeMinutes": {
-        "typeDefault": "number",
-        "typeOptions": ["number"],
-        "elasticsearch": {
-          "dataType": "long"
+      runtimeMinutes: {
+        typeDefault: 'number',
+        typeOptions: ['number'],
+        elasticsearch: {
+          dataType: 'long',
         },
-        "field": "runtimeMinutes",
-        "label": "Runtime Minutes",
-        "order": 0
+        field: 'runtimeMinutes',
+        label: 'Runtime Minutes',
+        order: 0,
       },
-      "title": {
-        "typeDefault": "facet",
-        "typeOptions": ["facet", "query"],
-        "elasticsearch": {
-          "dataType": "text",
-          "notAnalyzedField": "keyword"
+      title: {
+        typeDefault: 'facet',
+        typeOptions: ['facet', 'query'],
+        elasticsearch: {
+          dataType: 'text',
+          notAnalyzedField: 'keyword',
         },
-        "field": "title",
-        "label": "Title",
-        "order": 0
+        field: 'title',
+        label: 'Title',
+        order: 0,
       },
-      "type": {
-        "typeDefault": "facet",
-        "typeOptions": ["facet", "query"],
-        "elasticsearch": {
-          "dataType": "text",
-          "notAnalyzedField": "keyword"
+      type: {
+        typeDefault: 'facet',
+        typeOptions: ['facet', 'query'],
+        elasticsearch: {
+          dataType: 'text',
+          notAnalyzedField: 'keyword',
         },
-        "field": "type",
-        "label": "Type",
-        "order": 0
+        field: 'type',
+        label: 'Type',
+        order: 0,
       },
-      "writers": {
-        "typeDefault": "facet",
-        "typeOptions": ["facet", "query"],
-        "elasticsearch": {
-          "dataType": "text",
-          "notAnalyzedField": "keyword"
+      writers: {
+        typeDefault: 'facet',
+        typeOptions: ['facet', 'query'],
+        elasticsearch: {
+          dataType: 'text',
+          notAnalyzedField: 'keyword',
         },
-        "field": "writers",
-        "label": "Writers",
-        "order": 0
+        field: 'writers',
+        label: 'Writers',
+        order: 0,
       },
-      "year": {
-        "typeDefault": "number",
-        "typeOptions": ["number"],
-        "elasticsearch": {
-          "dataType": "long"
+      year: {
+        typeDefault: 'number',
+        typeOptions: ['number'],
+        elasticsearch: {
+          dataType: 'long',
         },
-        "field": "year",
-        "label": "Year",
-        "order": 0
+        field: 'year',
+        label: 'Year',
+        order: 0,
       },
-      "yearEnded": {
-        "typeDefault": "number",
-        "typeOptions": ["number"],
-        "elasticsearch": {
-          "dataType": "long"
+      yearEnded: {
+        typeDefault: 'number',
+        typeOptions: ['number'],
+        elasticsearch: {
+          dataType: 'long',
         },
-        "field": "yearEnded",
-        "label": "Year Ended",
-        "order": 0
-      }
-    }
-  }
+        field: 'yearEnded',
+        label: 'Year Ended',
+        order: 0,
+      },
+    },
+  },
 }

--- a/test/schema-data/imdb-schema.js
+++ b/test/schema-data/imdb-schema.js
@@ -1,0 +1,452 @@
+module.exports = {
+  "movies": {
+    "elasticsearch": {
+      "index": "movies",
+      "type": "movie"
+    },
+    "modeMap": {
+      "word": "",
+      "autocomplete": ".keyword"
+    },
+    "fields": {
+      "actors": {
+        "typeDefault": "facet",
+        "typeOptions": ["facet", "query"],
+        "elasticsearch": {
+          "dataType": "text",
+          "notAnalyzedField": "keyword"
+        },
+        "field": "actors",
+        "label": "Actors",
+        "order": 0
+      },
+      "awards": {
+        "typeDefault": "facet",
+        "typeOptions": ["facet", "query"],
+        "elasticsearch": {
+          "dataType": "text",
+          "notAnalyzedField": "keyword"
+        },
+        "field": "awards",
+        "label": "Awards",
+        "order": 0
+      },
+      "countries": {
+        "typeDefault": "facet",
+        "typeOptions": ["facet", "query"],
+        "elasticsearch": {
+          "dataType": "text",
+          "notAnalyzedField": "keyword"
+        },
+        "field": "countries",
+        "label": "Countries",
+        "order": 0
+      },
+      "directors": {
+        "typeDefault": "facet",
+        "typeOptions": ["facet", "query"],
+        "elasticsearch": {
+          "dataType": "text",
+          "notAnalyzedField": "keyword"
+        },
+        "field": "directors",
+        "label": "Directors",
+        "order": 0
+      },
+      "genres": {
+        "typeDefault": "facet",
+        "typeOptions": ["facet", "query"],
+        "elasticsearch": {
+          "dataType": "text",
+          "notAnalyzedField": "keyword"
+        },
+        "field": "genres",
+        "label": "Genres",
+        "order": 0
+      },
+      "imdbId": {
+        "typeDefault": "facet",
+        "typeOptions": ["facet", "query"],
+        "elasticsearch": {
+          "dataType": "text",
+          "notAnalyzedField": "keyword"
+        },
+        "field": "imdbId",
+        "label": "Imdb Id",
+        "order": 0
+      },
+      "imdbRating": {
+        "typeDefault": "number",
+        "typeOptions": ["number"],
+        "elasticsearch": {
+          "dataType": "float"
+        },
+        "field": "imdbRating",
+        "label": "Imdb Rating",
+        "order": 0
+      },
+      "imdbVotes": {
+        "typeDefault": "number",
+        "typeOptions": ["number"],
+        "elasticsearch": {
+          "dataType": "long"
+        },
+        "field": "imdbVotes",
+        "label": "Imdb Votes",
+        "order": 0
+      },
+      "languages": {
+        "typeDefault": "facet",
+        "typeOptions": ["facet", "query"],
+        "elasticsearch": {
+          "dataType": "text",
+          "notAnalyzedField": "keyword"
+        },
+        "field": "languages",
+        "label": "Languages",
+        "order": 0
+      },
+      "metaScore": {
+        "typeDefault": "number",
+        "typeOptions": ["number"],
+        "elasticsearch": {
+          "dataType": "long"
+        },
+        "field": "metaScore",
+        "label": "Meta Score",
+        "order": 0
+      },
+      "plot": {
+        "typeDefault": "facet",
+        "typeOptions": ["facet", "query"],
+        "elasticsearch": {
+          "dataType": "text",
+          "notAnalyzedField": "keyword"
+        },
+        "field": "plot",
+        "label": "Plot",
+        "order": 0
+      },
+      "poster": {
+        "typeDefault": "facet",
+        "typeOptions": ["facet", "query"],
+        "elasticsearch": {
+          "dataType": "text",
+          "notAnalyzedField": "keyword"
+        },
+        "field": "poster",
+        "label": "Poster",
+        "order": 0
+      },
+      "rated": {
+        "typeDefault": "facet",
+        "typeOptions": ["facet", "query"],
+        "elasticsearch": {
+          "dataType": "text",
+          "notAnalyzedField": "keyword"
+        },
+        "field": "rated",
+        "label": "Rated",
+        "order": 0
+      },
+      "released": {
+        "typeDefault": "date",
+        "typeOptions": ["date"],
+        "elasticsearch": {
+          "dataType": "date"
+        },
+        "field": "released",
+        "label": "Released",
+        "order": 0
+      },
+      "runtimeMinutes": {
+        "typeDefault": "number",
+        "typeOptions": ["number"],
+        "elasticsearch": {
+          "dataType": "long"
+        },
+        "field": "runtimeMinutes",
+        "label": "Runtime Minutes",
+        "order": 0
+      },
+      "title": {
+        "typeDefault": "facet",
+        "typeOptions": ["facet", "query"],
+        "elasticsearch": {
+          "dataType": "text",
+          "notAnalyzedField": "keyword"
+        },
+        "field": "title",
+        "label": "Title",
+        "order": 0
+      },
+      "type": {
+        "typeDefault": "facet",
+        "typeOptions": ["facet", "query"],
+        "elasticsearch": {
+          "dataType": "text",
+          "notAnalyzedField": "keyword"
+        },
+        "field": "type",
+        "label": "Type",
+        "order": 0
+      },
+      "writers": {
+        "typeDefault": "facet",
+        "typeOptions": ["facet", "query"],
+        "elasticsearch": {
+          "dataType": "text",
+          "notAnalyzedField": "keyword"
+        },
+        "field": "writers",
+        "label": "Writers",
+        "order": 0
+      },
+      "year": {
+        "typeDefault": "number",
+        "typeOptions": ["number"],
+        "elasticsearch": {
+          "dataType": "long"
+        },
+        "field": "year",
+        "label": "Year",
+        "order": 0
+      },
+      "yearEnded": {
+        "typeDefault": "number",
+        "typeOptions": ["number"],
+        "elasticsearch": {
+          "dataType": "long"
+        },
+        "field": "yearEnded",
+        "label": "Year Ended",
+        "order": 0
+      }
+    }
+  },
+  "imdb": {
+    "elasticsearch": {
+      "index": "imdb",
+      "type": "movie"
+    },
+    "modeMap": {
+      "word": "",
+      "autocomplete": ".keyword"
+    },
+    "fields": {
+      "actors": {
+        "typeDefault": "facet",
+        "typeOptions": ["facet", "query"],
+        "elasticsearch": {
+          "dataType": "text",
+          "notAnalyzedField": "keyword"
+        },
+        "field": "actors",
+        "label": "Actors",
+        "order": 0
+      },
+      "awards": {
+        "typeDefault": "facet",
+        "typeOptions": ["facet", "query"],
+        "elasticsearch": {
+          "dataType": "text",
+          "notAnalyzedField": "keyword"
+        },
+        "field": "awards",
+        "label": "Awards",
+        "order": 0
+      },
+      "countries": {
+        "typeDefault": "facet",
+        "typeOptions": ["facet", "query"],
+        "elasticsearch": {
+          "dataType": "text",
+          "notAnalyzedField": "keyword"
+        },
+        "field": "countries",
+        "label": "Countries",
+        "order": 0
+      },
+      "directors": {
+        "typeDefault": "facet",
+        "typeOptions": ["facet", "query"],
+        "elasticsearch": {
+          "dataType": "text",
+          "notAnalyzedField": "keyword"
+        },
+        "field": "directors",
+        "label": "Directors",
+        "order": 0
+      },
+      "genres": {
+        "typeDefault": "facet",
+        "typeOptions": ["facet", "query"],
+        "elasticsearch": {
+          "dataType": "text",
+          "notAnalyzedField": "keyword"
+        },
+        "field": "genres",
+        "label": "Genres",
+        "order": 0
+      },
+      "imdbId": {
+        "typeDefault": "facet",
+        "typeOptions": ["facet", "query"],
+        "elasticsearch": {
+          "dataType": "text",
+          "notAnalyzedField": "keyword"
+        },
+        "field": "imdbId",
+        "label": "Imdb Id",
+        "order": 0
+      },
+      "imdbRating": {
+        "typeDefault": "number",
+        "typeOptions": ["number"],
+        "elasticsearch": {
+          "dataType": "float"
+        },
+        "field": "imdbRating",
+        "label": "Imdb Rating",
+        "order": 0
+      },
+      "imdbVotes": {
+        "typeDefault": "number",
+        "typeOptions": ["number"],
+        "elasticsearch": {
+          "dataType": "long"
+        },
+        "field": "imdbVotes",
+        "label": "Imdb Votes",
+        "order": 0
+      },
+      "languages": {
+        "typeDefault": "facet",
+        "typeOptions": ["facet", "query"],
+        "elasticsearch": {
+          "dataType": "text",
+          "notAnalyzedField": "keyword"
+        },
+        "field": "languages",
+        "label": "Languages",
+        "order": 0
+      },
+      "metaScore": {
+        "typeDefault": "number",
+        "typeOptions": ["number"],
+        "elasticsearch": {
+          "dataType": "long"
+        },
+        "field": "metaScore",
+        "label": "Meta Score",
+        "order": 0
+      },
+      "plot": {
+        "typeDefault": "facet",
+        "typeOptions": ["facet", "query"],
+        "elasticsearch": {
+          "dataType": "text",
+          "notAnalyzedField": "keyword"
+        },
+        "field": "plot",
+        "label": "Plot",
+        "order": 0
+      },
+      "poster": {
+        "typeDefault": "facet",
+        "typeOptions": ["facet", "query"],
+        "elasticsearch": {
+          "dataType": "text",
+          "notAnalyzedField": "keyword"
+        },
+        "field": "poster",
+        "label": "Poster",
+        "order": 0
+      },
+      "rated": {
+        "typeDefault": "facet",
+        "typeOptions": ["facet", "query"],
+        "elasticsearch": {
+          "dataType": "text",
+          "notAnalyzedField": "keyword"
+        },
+        "field": "rated",
+        "label": "Rated",
+        "order": 0
+      },
+      "released": {
+        "typeDefault": "date",
+        "typeOptions": ["date"],
+        "elasticsearch": {
+          "dataType": "date"
+        },
+        "field": "released",
+        "label": "Released",
+        "order": 0
+      },
+      "runtimeMinutes": {
+        "typeDefault": "number",
+        "typeOptions": ["number"],
+        "elasticsearch": {
+          "dataType": "long"
+        },
+        "field": "runtimeMinutes",
+        "label": "Runtime Minutes",
+        "order": 0
+      },
+      "title": {
+        "typeDefault": "facet",
+        "typeOptions": ["facet", "query"],
+        "elasticsearch": {
+          "dataType": "text",
+          "notAnalyzedField": "keyword"
+        },
+        "field": "title",
+        "label": "Title",
+        "order": 0
+      },
+      "type": {
+        "typeDefault": "facet",
+        "typeOptions": ["facet", "query"],
+        "elasticsearch": {
+          "dataType": "text",
+          "notAnalyzedField": "keyword"
+        },
+        "field": "type",
+        "label": "Type",
+        "order": 0
+      },
+      "writers": {
+        "typeDefault": "facet",
+        "typeOptions": ["facet", "query"],
+        "elasticsearch": {
+          "dataType": "text",
+          "notAnalyzedField": "keyword"
+        },
+        "field": "writers",
+        "label": "Writers",
+        "order": 0
+      },
+      "year": {
+        "typeDefault": "number",
+        "typeOptions": ["number"],
+        "elasticsearch": {
+          "dataType": "long"
+        },
+        "field": "year",
+        "label": "Year",
+        "order": 0
+      },
+      "yearEnded": {
+        "typeDefault": "number",
+        "typeOptions": ["number"],
+        "elasticsearch": {
+          "dataType": "long"
+        },
+        "field": "yearEnded",
+        "label": "Year Ended",
+        "order": 0
+      }
+    }
+  }
+}

--- a/test/schema.js
+++ b/test/schema.js
@@ -1,15 +1,18 @@
 let _ = require('lodash/fp')
 let F = require('futil-js')
 
-let {fromMappingsWithAliases} = require('../src/schema')
-let {exampleTypeSchemaMapping} = require('../src/example-types/schemaMapping')
+let { fromMappingsWithAliases } = require('../src/schema')
+let { exampleTypeSchemaMapping } = require('../src/example-types/schemaMapping')
 let { expect } = require('chai')
 
 let imdbMapping = require('./schema-data/imdb-mapping')
 let imdbAliases = require('./schema-data/imdb-aliases')
 let imdbSchema = require('./schema-data/imdb-schema')
 
-let processSchemas = _.flow(fromMappingsWithAliases, exampleTypeSchemaMapping)
+let processSchemas = _.flow(
+  fromMappingsWithAliases,
+  exampleTypeSchemaMapping
+)
 
 describe.only('schemas', () => {
   it('should work with imdb', () => {

--- a/test/schema.js
+++ b/test/schema.js
@@ -14,7 +14,7 @@ let processSchemas = _.flow(
   exampleTypeSchemaMapping
 )
 
-describe.only('schemas', () => {
+describe('schemas', () => {
   it('should work with imdb', () => {
     let result = processSchemas(imdbMapping, imdbAliases)
     //console.log(JSON.stringify(result))

--- a/test/schema.js
+++ b/test/schema.js
@@ -1,5 +1,4 @@
 let _ = require('lodash/fp')
-let F = require('futil-js')
 
 let { fromMappingsWithAliases } = require('../src/schema')
 let { exampleTypeSchemaMapping } = require('../src/example-types/schemaMapping')

--- a/test/schema.js
+++ b/test/schema.js
@@ -1,0 +1,20 @@
+let _ = require('lodash/fp')
+let F = require('futil-js')
+
+let {fromMappingsWithAliases} = require('../src/schema')
+let {exampleTypeSchemaMapping} = require('../src/example-types/schemaMapping')
+let { expect } = require('chai')
+
+let imdbMapping = require('./schema-data/imdb-mapping')
+let imdbAliases = require('./schema-data/imdb-aliases')
+let imdbSchema = require('./schema-data/imdb-schema')
+
+let processSchemas = _.flow(fromMappingsWithAliases, exampleTypeSchemaMapping)
+
+describe.only('schemas', () => {
+  it('should work with imdb', () => {
+    let result = processSchemas(imdbMapping, imdbAliases)
+    //console.log(JSON.stringify(result))
+    expect(result).to.deep.equal(imdbSchema)
+  })
+})

--- a/test/types.js
+++ b/test/types.js
@@ -7,7 +7,6 @@ describe('All Example Types', function() {
   it('should load', () => {
     let types = Types()
     expect(_.keys(types)).to.have.members([
-      '__all',
       'bool',
       'cardinality',
       'date',


### PR DESCRIPTION
Closes #86

* Format CHANGELOG
* Added `getSchemas`, a utility that reads from es mappings/aliases to automatically generate schemas (complete with field definitions as well)
* Added `exampleTypeSchemaMapping` to map es types to example contexture node types