### PR TITLE
Avoid object spread in mapping util to make browser usage easier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.10.1
+* Avoid object spread in mapping util to make browser usage easier
+
 # 0.10.0
 * Format CHANGELOG
 * Added `getSchemas`, a utility that reads from es mappings/aliases to automatically generate schemas (complete with field definitions as well)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/schemaMapping.js
+++ b/src/example-types/schemaMapping.js
@@ -10,14 +10,16 @@ let addNodeType = x => {
     float: 'number',
     double: 'number',
   })
-  return {
-    typeDefault,
-    // TODO: exists, bool, geo, text
-    typeOptions: {
-      text: ['facet', 'query'],
-    }[type] || [typeDefault],
-    ...x,
-  }
+  return _.extend(
+    {
+      typeDefault,
+      // TODO: exists, bool, geo, text
+      typeOptions: {
+        text: ['facet', 'query'],
+      }[type] || [typeDefault],
+    },
+    x
+  )
 }
 let exampleTypeSchemaMapping = _.mapValues(
   _.update('fields', _.mapValues(addNodeType))


### PR DESCRIPTION
* Avoid object spread in mapping util to make browser usage easier
