### PR TITLE
Handle empty mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-﻿# 0.12.2
+﻿# 0.12.3
+* Apparently mappings can sometimes be empty, so omit them from schema processing to be safe
+
+# 0.12.2
 * Added support for fieldMode on the cardinality type.
 
 # 0.12.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/schema.js
+++ b/src/schema.js
@@ -70,7 +70,9 @@ let copySchemasToAliases = schemas =>
   )
 
 let fromMappingsWithAliases = (mappings, aliases) => {
-  let schemas = fromEsIndexMapping(mappings)
+  // Apparently mappings can sometimes be empty, so omit them to be safe
+  let safeMappings = _.omitBy(index => _.isEmpty(index.mappings), mappings)
+  let schemas = fromEsIndexMapping(safeMappings)
   return _.flow(
     copySchemasToAliases(schemas),
     _.merge(schemas),

--- a/test/schema-data/imdb-mapping.js
+++ b/test/schema-data/imdb-mapping.js
@@ -146,6 +146,6 @@ module.exports = {
     },
   },
   weirdEmptyIndexThatWeWillNowIgnore: {
-    mappings: {}
-  }
+    mappings: {},
+  },
 }

--- a/test/schema-data/imdb-mapping.js
+++ b/test/schema-data/imdb-mapping.js
@@ -145,4 +145,7 @@ module.exports = {
       },
     },
   },
+  weirdEmptyIndexThatWeWillNowIgnore: {
+    mappings: {}
+  }
 }


### PR DESCRIPTION
Apparently mappings can sometimes be empty, so omit them to be safe