### PR TITLE
Fix index name beginning with period breaks schema to alias mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.14.2
+* Only select field values that are arrays when mapping indices to aliases in copySchemasToAliases
+
 # 0.14.1
 * Fixes tagQuery isPhrase
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/schema.js
+++ b/src/schema.js
@@ -65,6 +65,8 @@ let copySchemasToAliases = schemas =>
   _.flow(
     _.mapValues(x => _.keys(x.aliases)),
     F.invertByArray,
+    // only select field values which are arrays
+    _.pickBy(_.isArray),
     // Just takes the first index that matched the alias
     _.mapValues(([x]) => schemas[x])
   )


### PR DESCRIPTION
When ES index name starts with a period, the F method invertByArray creates a field which has a value 
 which is not an array and the deconstruct in the following _.mapValues fails. Here is an example of what invertByArray produces when an index name starts with a period:

```
{ '': { kibana: [ '.kibana_1' ] },
  'bid-data': [ 'bid-2018.10.31' ],
  'bid-data-beta': [ 'bid-2018.10.31' ],
  'include-in-snapshot': [ 'bid-2018.10.31', 'bid-2018.12.20', 'bid-2018.12.28b' ],
  'cage-data': [ 'cage-20170507-es6' ],
  'fpds-current': [ 'fpds-20180811-es6' ],
  'fpds-documents': [ 'fpds-20180811-es6' ],
  fpds_current: [ 'fpds-20180811-es6' ],
  'gov-contacts': [ 'gov-contacts-2018.06.21c-es6-2' ],
  'gsa-data-import': [ 'gsa-20171228-es6-2' ],
  'nsn-data': [ 'nsn-20170507-es6-2' ],
  'smartcontacts-data-import': [ 'smartcontacts-20171221b-es6-2' ],
  'sp-data':
   [ 'sp-data-20181122-ct',
     'sp-data-20181122-lit',
     'sp-data-20181122-ot',
     'sp-data-20181122-vlct',
     'sp-data-20181122-vt' ],
  'sp-data-20181122':
   [ 'sp-data-20181122-ct',
     'sp-data-20181122-lit',
     'sp-data-20181122-ot',
     'sp-data-20181122-vlct',
     'sp-data-20181122-vt' ],
  'sp-data-ct': [ 'sp-data-20181122-ct' ],
  sp_data_ct: [ 'sp-data-20181122-ct' ],
  'sp-data-lit': [ 'sp-data-20181122-lit' ],
  sp_data_lit: [ 'sp-data-20181122-lit' ],
  'sp-data-ot': [ 'sp-data-20181122-ot' ],
  sp_data_ot: [ 'sp-data-20181122-ot' ],
  'sp-data-vlct': [ 'sp-data-20181122-vlct' ],
  sp_data_vlct: [ 'sp-data-20181122-vlct' ],
  'sp-data-vt': [ 'sp-data-20181122-vt' ],
  sp_data_vt: [ 'sp-data-20181122-vt' ],
  'unspsc-beta': [ 'unspsc-20190103' ],
  'unspsc-data': [ 'unspsc-20190103' ] }
```