### PR TITLE
Subquery prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.15.0
+* Globally check for `notAnalyzedField` from field util instead of just results
+* Fix scan/scroll on latest core (don't check `config`)
+* Support `scroll: true` which now defaults to 2m instead of exploding
+* Support tagsText in typeOptions for text fields
+* Facet: Add explicit size:0 support (which sets it to es's max integer size of `2^31 - 1`)
+
 # 0.14.2
 * Only select field values that are arrays when mapping indices to aliases in copySchemasToAliases
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "0.14.2",
+  "version": "0.15.0",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/facet.js
+++ b/src/example-types/facet.js
@@ -4,7 +4,7 @@ let { buildRegexQueryForWords, buildRegexForWords } = require('../regex')
 let { getField } = require('../fields')
 
 // https://www.elastic.co/guide/en/elasticsearch/reference/current/number.html#number
-const elasticsearchIntegerMax = (2**31) - 1
+const elasticsearchIntegerMax = 2 ** 31 - 1
 
 module.exports = {
   hasValue: context => _.get('values.length', context),
@@ -47,7 +47,9 @@ module.exports = {
             {
               field,
               // Size 0 no longer supported natively by ES: https://github.com/elastic/elasticsearch/issues/18838
-              size: context.size || (context.size === 0 ? elasticsearchIntegerMax : 10),
+              size:
+                context.size ||
+                (context.size === 0 ? elasticsearchIntegerMax : 10),
               order: {
                 term: { _term: 'asc' },
                 count: { _count: 'desc' },

--- a/src/example-types/facet.js
+++ b/src/example-types/facet.js
@@ -3,6 +3,9 @@ let F = require('futil-js')
 let { buildRegexQueryForWords, buildRegexForWords } = require('../regex')
 let { getField } = require('../fields')
 
+// https://www.elastic.co/guide/en/elasticsearch/reference/current/number.html#number
+const elasticsearchIntegerMax = (2**31) - 1
+
 module.exports = {
   hasValue: context => _.get('values.length', context),
   filter(context, schema = {}) {
@@ -43,7 +46,8 @@ module.exports = {
           terms: _.extendAll([
             {
               field,
-              size: context.size || context.size === 0 ? context.size : 10,
+              // Size 0 no longer supported natively by ES: https://github.com/elastic/elasticsearch/issues/18838
+              size: context.size || (context.size === 0 ? elasticsearchIntegerMax : 10),
               order: {
                 term: { _term: 'asc' },
                 count: { _count: 'desc' },

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -1,31 +1,17 @@
 let F = require('futil-js')
 let _ = require('lodash/fp')
 let highlightResults = require('../highlighting').highlightResults
+let { getField } = require('../fields')
 
-const sortModeMap = {
-  field: '.untouched',
-  word: '',
-}
-const getSortField = (context, schema) => {
-  let suffix = _.get(
-    [context.sortField, 'elasticsearch', 'notAnalyzedField'],
-    schema.fields
-  )
-  if (!suffix) {
-    context.sortField =
-      _.replace('.untouched', '', context.sortField) +
-      _.getOr('', context.sortMode, sortModeMap)
-  }
-  return suffix && !_.endsWith(`.${suffix}`, context.sortField)
-    ? `${context.sortField}.${suffix}`
-    : context.sortField
-}
 module.exports = {
   result(context, search, schema) {
     let page = (context.page || 1) - 1
     let pageSize = context.pageSize || 10
     let startRecord = page * pageSize
-    let sortField = context.sortField ? getSortField(context, schema) : '_score'
+    let sortField = context.sortField
+      // default to word (aka '') for backwards compatibility
+      ? getField(schema, context.sortField, context.sortMode || 'word')
+      : '_score'
     let sortDir = context.sortDir || 'desc'
     let result = {
       from: startRecord,

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -9,8 +9,8 @@ module.exports = {
     let pageSize = context.pageSize || 10
     let startRecord = page * pageSize
     let sortField = context.sortField
-      // default to word (aka '') for backwards compatibility
-      ? getField(schema, context.sortField, context.sortMode || 'word')
+      ? // default to word (aka '') for backwards compatibility
+        getField(schema, context.sortField, context.sortMode || 'word')
       : '_score'
     let sortDir = context.sortDir || 'desc'
     let result = {

--- a/src/example-types/schemaMapping.js
+++ b/src/example-types/schemaMapping.js
@@ -18,7 +18,7 @@ let addNodeType = x => {
     {
       typeDefault,
       typeOptions: {
-        text: hasNested ? ['facet', 'tagsQuery', 'exists'] : null,
+        text: hasNested ? ['facet', 'tagsQuery', 'tagsText', 'exists'] : null,
       }[type] || [typeDefault, 'exists'],
     },
     x

--- a/src/fields.js
+++ b/src/fields.js
@@ -1,14 +1,25 @@
 let _ = require('lodash/fp')
+let F = require('futil-js')
+
 let rawFieldName = _.replace(/(\.untouched)|(\.shingle)/g, '')
 let modeMap = {
   word: '',
-  autocomplete: '.untouched',
-  suggest: '.shingle',
+  autocomplete: 'untouched',
+  field: 'untouched',
+  suggest: 'shingle',
 }
 module.exports = {
-  getField: (schema, field, fieldMode = 'autocomplete') =>
-    schema.getField
-      ? schema.getField(schema, field, fieldMode)
-      : (schema.rawFieldName || rawFieldName)(field) +
-        (schema.modeMap || modeMap)[fieldMode],
+  getField: (schema, field, fieldMode = 'autocomplete') => {
+    if (schema.getField)
+      return schema.getField(schema, field, fieldMode)
+    
+    let fieldName = (schema.rawFieldName || rawFieldName)(field)
+    // Maintains backwards compatibility with "modeMap" approach
+    let suffix = schema.fields
+      ? _.get([fieldName, 'elasticsearch', 'notAnalyzedField'], schema.fields)
+      : (schema.modeMap || modeMap)[fieldMode]
+    return _.endsWith(suffix, fieldName)
+      ? fieldName
+      : F.compactJoin('.', [fieldName, suffix])
+  }
 }

--- a/src/fields.js
+++ b/src/fields.js
@@ -9,10 +9,9 @@ let modeMap = {
   suggest: 'shingle',
 }
 module.exports = {
-  getField: (schema, field, fieldMode = 'autocomplete') => {
-    if (schema.getField)
-      return schema.getField(schema, field, fieldMode)
-    
+  getField(schema, field, fieldMode = 'autocomplete') {
+    if (schema.getField) return schema.getField(schema, field, fieldMode)
+
     let fieldName = (schema.rawFieldName || rawFieldName)(field)
     // Maintains backwards compatibility with "modeMap" approach
     let suffix = schema.fields
@@ -21,5 +20,5 @@ module.exports = {
     return _.endsWith(suffix, fieldName)
       ? fieldName
       : F.compactJoin('.', [fieldName, suffix])
-  }
+  },
 }

--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,7 @@ let ElasticsearchProvider = (
         index: schema.elasticsearch.index,
 
         // Scroll Support
-        scroll: context.scroll,
+        scroll: context.scroll === true ? '2m' : context.scroll,
         // searchType:         context.searchType
       },
       config.request,

--- a/src/index.js
+++ b/src/index.js
@@ -54,8 +54,8 @@ let ElasticsearchProvider = (
         index: schema.elasticsearch.index,
 
         // Scroll Support
-        scroll: context.config.scroll,
-        // searchType:         context.config.searchType
+        scroll: context.scroll,
+        // searchType:         context.searchType
       },
       config.request,
       request,
@@ -72,17 +72,17 @@ let ElasticsearchProvider = (
     })
 
     // Required for scroll since 2.1.0 ES
-    if (context.config.scroll) {
+    if (context.scroll) {
       request.body.sort = ['_doc']
-      request.size = context.config.size
+      request.size = context.size
     }
     // Run Search
-    let scrollId = context.config.scrollId
+    let scrollId = context.scrollId
     let client = config.getClient()
     // If we have scrollId then keep scrolling if not search
     let result = scrollId
       ? client.scroll({
-          scroll: context.config.scroll,
+          scroll: context.scroll,
           scrollId,
         })
       : client.search(request)

--- a/test/example-types/facet.js
+++ b/test/example-types/facet.js
@@ -153,6 +153,55 @@ describe('facet', () => {
         ]
       ))
 
+    it('size 0', () =>
+      facetTest(
+        {
+          key: 'test',
+          type: 'facet',
+          field: 'testField.untouched',
+          values: ['a'],
+          size: 0,
+        },
+        {
+          cardinality: 10,
+          options: [
+            {
+              name: 'a',
+              count: 10,
+            },
+            {
+              name: 'b',
+              count: 10,
+            },
+            {
+              name: 'c',
+              count: 10,
+            },
+          ],
+        },
+        [
+          {
+            aggs: {
+              facetOptions: {
+                terms: {
+                  field: 'testField.untouched',
+                  size: (2**31) - 1,
+                  order: {
+                    _count: 'desc',
+                  },
+                },
+              },
+              facetCardinality: {
+                cardinality: {
+                  field: 'testField.untouched',
+                  precision_threshold: 5000,
+                },
+              },
+            },
+          },
+        ]
+      ))
+
     it('missing values', () =>
       facetTest(
         {

--- a/test/example-types/facet.js
+++ b/test/example-types/facet.js
@@ -185,7 +185,7 @@ describe('facet', () => {
               facetOptions: {
                 terms: {
                   field: 'testField.untouched',
-                  size: (2**31) - 1,
+                  size: 2 ** 31 - 1,
                   order: {
                     _count: 'desc',
                   },

--- a/test/schema-data/imdb-schema.js
+++ b/test/schema-data/imdb-schema.js
@@ -11,7 +11,7 @@ module.exports = {
     fields: {
       actors: {
         typeDefault: 'facet',
-        typeOptions: ['facet', 'tagsQuery', 'exists'],
+        typeOptions: ['facet', 'tagsQuery', 'tagsText', 'exists'],
         elasticsearch: {
           dataType: 'text',
           notAnalyzedField: 'keyword',
@@ -22,7 +22,7 @@ module.exports = {
       },
       awards: {
         typeDefault: 'facet',
-        typeOptions: ['facet', 'tagsQuery', 'exists'],
+        typeOptions: ['facet', 'tagsQuery', 'tagsText', 'exists'],
         elasticsearch: {
           dataType: 'text',
           notAnalyzedField: 'keyword',
@@ -33,7 +33,7 @@ module.exports = {
       },
       countries: {
         typeDefault: 'facet',
-        typeOptions: ['facet', 'tagsQuery', 'exists'],
+        typeOptions: ['facet', 'tagsQuery', 'tagsText', 'exists'],
         elasticsearch: {
           dataType: 'text',
           notAnalyzedField: 'keyword',
@@ -44,7 +44,7 @@ module.exports = {
       },
       directors: {
         typeDefault: 'facet',
-        typeOptions: ['facet', 'tagsQuery', 'exists'],
+        typeOptions: ['facet', 'tagsQuery', 'tagsText', 'exists'],
         elasticsearch: {
           dataType: 'text',
           notAnalyzedField: 'keyword',
@@ -55,7 +55,7 @@ module.exports = {
       },
       genres: {
         typeDefault: 'facet',
-        typeOptions: ['facet', 'tagsQuery', 'exists'],
+        typeOptions: ['facet', 'tagsQuery', 'tagsText', 'exists'],
         elasticsearch: {
           dataType: 'text',
           notAnalyzedField: 'keyword',
@@ -66,7 +66,7 @@ module.exports = {
       },
       imdbId: {
         typeDefault: 'facet',
-        typeOptions: ['facet', 'tagsQuery', 'exists'],
+        typeOptions: ['facet', 'tagsQuery', 'tagsText', 'exists'],
         elasticsearch: {
           dataType: 'text',
           notAnalyzedField: 'keyword',
@@ -97,7 +97,7 @@ module.exports = {
       },
       languages: {
         typeDefault: 'facet',
-        typeOptions: ['facet', 'tagsQuery', 'exists'],
+        typeOptions: ['facet', 'tagsQuery', 'tagsText', 'exists'],
         elasticsearch: {
           dataType: 'text',
           notAnalyzedField: 'keyword',
@@ -118,7 +118,7 @@ module.exports = {
       },
       plot: {
         typeDefault: 'facet',
-        typeOptions: ['facet', 'tagsQuery', 'exists'],
+        typeOptions: ['facet', 'tagsQuery', 'tagsText', 'exists'],
         elasticsearch: {
           dataType: 'text',
           notAnalyzedField: 'keyword',
@@ -129,7 +129,7 @@ module.exports = {
       },
       poster: {
         typeDefault: 'facet',
-        typeOptions: ['facet', 'tagsQuery', 'exists'],
+        typeOptions: ['facet', 'tagsQuery', 'tagsText', 'exists'],
         elasticsearch: {
           dataType: 'text',
           notAnalyzedField: 'keyword',
@@ -140,7 +140,7 @@ module.exports = {
       },
       rated: {
         typeDefault: 'facet',
-        typeOptions: ['facet', 'tagsQuery', 'exists'],
+        typeOptions: ['facet', 'tagsQuery', 'tagsText', 'exists'],
         elasticsearch: {
           dataType: 'text',
           notAnalyzedField: 'keyword',
@@ -171,7 +171,7 @@ module.exports = {
       },
       title: {
         typeDefault: 'facet',
-        typeOptions: ['facet', 'tagsQuery', 'exists'],
+        typeOptions: ['facet', 'tagsQuery', 'tagsText', 'exists'],
         elasticsearch: {
           dataType: 'text',
           notAnalyzedField: 'keyword',
@@ -182,7 +182,7 @@ module.exports = {
       },
       type: {
         typeDefault: 'facet',
-        typeOptions: ['facet', 'tagsQuery', 'exists'],
+        typeOptions: ['facet', 'tagsQuery', 'tagsText', 'exists'],
         elasticsearch: {
           dataType: 'text',
           notAnalyzedField: 'keyword',
@@ -193,7 +193,7 @@ module.exports = {
       },
       writers: {
         typeDefault: 'facet',
-        typeOptions: ['facet', 'tagsQuery', 'exists'],
+        typeOptions: ['facet', 'tagsQuery', 'tagsText', 'exists'],
         elasticsearch: {
           dataType: 'text',
           notAnalyzedField: 'keyword',
@@ -236,7 +236,7 @@ module.exports = {
     fields: {
       actors: {
         typeDefault: 'facet',
-        typeOptions: ['facet', 'tagsQuery', 'exists'],
+        typeOptions: ['facet', 'tagsQuery', 'tagsText', 'exists'],
         elasticsearch: {
           dataType: 'text',
           notAnalyzedField: 'keyword',
@@ -247,7 +247,7 @@ module.exports = {
       },
       awards: {
         typeDefault: 'facet',
-        typeOptions: ['facet', 'tagsQuery', 'exists'],
+        typeOptions: ['facet', 'tagsQuery', 'tagsText', 'exists'],
         elasticsearch: {
           dataType: 'text',
           notAnalyzedField: 'keyword',
@@ -258,7 +258,7 @@ module.exports = {
       },
       countries: {
         typeDefault: 'facet',
-        typeOptions: ['facet', 'tagsQuery', 'exists'],
+        typeOptions: ['facet', 'tagsQuery', 'tagsText', 'exists'],
         elasticsearch: {
           dataType: 'text',
           notAnalyzedField: 'keyword',
@@ -269,7 +269,7 @@ module.exports = {
       },
       directors: {
         typeDefault: 'facet',
-        typeOptions: ['facet', 'tagsQuery', 'exists'],
+        typeOptions: ['facet', 'tagsQuery', 'tagsText', 'exists'],
         elasticsearch: {
           dataType: 'text',
           notAnalyzedField: 'keyword',
@@ -280,7 +280,7 @@ module.exports = {
       },
       genres: {
         typeDefault: 'facet',
-        typeOptions: ['facet', 'tagsQuery', 'exists'],
+        typeOptions: ['facet', 'tagsQuery', 'tagsText', 'exists'],
         elasticsearch: {
           dataType: 'text',
           notAnalyzedField: 'keyword',
@@ -291,7 +291,7 @@ module.exports = {
       },
       imdbId: {
         typeDefault: 'facet',
-        typeOptions: ['facet', 'tagsQuery', 'exists'],
+        typeOptions: ['facet', 'tagsQuery', 'tagsText', 'exists'],
         elasticsearch: {
           dataType: 'text',
           notAnalyzedField: 'keyword',
@@ -322,7 +322,7 @@ module.exports = {
       },
       languages: {
         typeDefault: 'facet',
-        typeOptions: ['facet', 'tagsQuery', 'exists'],
+        typeOptions: ['facet', 'tagsQuery', 'tagsText', 'exists'],
         elasticsearch: {
           dataType: 'text',
           notAnalyzedField: 'keyword',
@@ -343,7 +343,7 @@ module.exports = {
       },
       plot: {
         typeDefault: 'facet',
-        typeOptions: ['facet', 'tagsQuery', 'exists'],
+        typeOptions: ['facet', 'tagsQuery', 'tagsText', 'exists'],
         elasticsearch: {
           dataType: 'text',
           notAnalyzedField: 'keyword',
@@ -354,7 +354,7 @@ module.exports = {
       },
       poster: {
         typeDefault: 'facet',
-        typeOptions: ['facet', 'tagsQuery', 'exists'],
+        typeOptions: ['facet', 'tagsQuery', 'tagsText', 'exists'],
         elasticsearch: {
           dataType: 'text',
           notAnalyzedField: 'keyword',
@@ -365,7 +365,7 @@ module.exports = {
       },
       rated: {
         typeDefault: 'facet',
-        typeOptions: ['facet', 'tagsQuery', 'exists'],
+        typeOptions: ['facet', 'tagsQuery', 'tagsText', 'exists'],
         elasticsearch: {
           dataType: 'text',
           notAnalyzedField: 'keyword',
@@ -396,7 +396,7 @@ module.exports = {
       },
       title: {
         typeDefault: 'facet',
-        typeOptions: ['facet', 'tagsQuery', 'exists'],
+        typeOptions: ['facet', 'tagsQuery', 'tagsText', 'exists'],
         elasticsearch: {
           dataType: 'text',
           notAnalyzedField: 'keyword',
@@ -407,7 +407,7 @@ module.exports = {
       },
       type: {
         typeDefault: 'facet',
-        typeOptions: ['facet', 'tagsQuery', 'exists'],
+        typeOptions: ['facet', 'tagsQuery', 'tagsText', 'exists'],
         elasticsearch: {
           dataType: 'text',
           notAnalyzedField: 'keyword',
@@ -418,7 +418,7 @@ module.exports = {
       },
       writers: {
         typeDefault: 'facet',
-        typeOptions: ['facet', 'tagsQuery', 'exists'],
+        typeOptions: ['facet', 'tagsQuery', 'tagsText', 'exists'],
         elasticsearch: {
           dataType: 'text',
           notAnalyzedField: 'keyword',


### PR DESCRIPTION
* Globally check for `notAnalyzedField` from field util instead of just results
* Fix scan/scroll on latest core (don't check `config`)
* Support `scroll: true` which now defaults to 2m instead of exploding
* Support tagsText in typeOptions for text fields
* Facet: Add explicit size:0 support (which sets it to es's max integer size of `2^31 - 1`)