### PR TITLE
feature/117 - restrict ES highlighting to included fields unless context.showOtherMatches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.15.3
+* Restrict results context highlighting to includes unless context.showOtherMatches
+
 # 0.15.2
 * Fix typo on `tagsText` example type
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.15.3
+# 0.16.0
 * Restrict results context highlighting to includes unless context.showOtherMatches
 
 # 0.15.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "0.15.3",
+  "version": "0.16.0",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -30,6 +30,7 @@ module.exports = {
     if (context.exclude) result._source.excludes = context.exclude
     let highlight =
       _.getOr(true, 'highlight', context) && schema.elasticsearch.highlight
+    console.log({ highlight })
     if (highlight) {
       let schemaHiglightFields = _.flatten(
         _.values(schema.elasticsearch.highlight)

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -31,7 +31,10 @@ module.exports = {
     let highlight =
       _.getOr(true, 'highlight', context) && schema.elasticsearch.highlight
     if (highlight) {
-      let highlightFields = _.flatten(_.values(schema.elasticsearch.highlight))
+      let schemaHiglightFields = _.flatten(_.values(schema.elasticsearch.highlight))
+      let highlightFields = _.get('showOtherMatches', context)
+        ? schemaHiglightFields
+        : _.intersection(context.include, schemaHiglightFields)
       F.extendOn(result, {
         highlight: {
           pre_tags: ['<b>'],

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -30,7 +30,6 @@ module.exports = {
     if (context.exclude) result._source.excludes = context.exclude
     let highlight =
       _.getOr(true, 'highlight', context) && schema.elasticsearch.highlight
-    console.log({ highlight })
     if (highlight) {
       let schemaHiglightFields = _.flatten(
         _.values(schema.elasticsearch.highlight)

--- a/test/example-types/results.js
+++ b/test/example-types/results.js
@@ -163,8 +163,8 @@ describe('results', () => {
       }),
     ])
   })
-  it('should sort on "_score: desc" with no sortField config', async () =>
-    resultsTest(context, [
+  it('should sort on "_score: desc" with no sortField config', () =>
+   resultsTest(context, [
       _.extend(expectedCalls[0], {
         sort: {
           _score: 'desc',

--- a/test/example-types/results.js
+++ b/test/example-types/results.js
@@ -105,8 +105,16 @@ describe('results', () => {
     service[0].hits.hits[0].anotherField = 'test another field'
     F.extendOn(context, { showOtherMatches: true, include: 'anotherField', highlight: true })
     expectedResult.response.results[0].anotherField = 'test another field'
+    expectedResult.response.results[0].hit = {
+      _id: 'test-id',
+      field: 'test field',
+      anotherField: 'test another field'
+    }
     await resultsTest(context, [
       _.extend(expectedCalls[0], {
+        _source: {
+          includes: 'anotherField',
+        },
         sort: {
           _score: 'desc',
         },
@@ -117,8 +125,16 @@ describe('results', () => {
     service[0].hits.hits[0].anotherField = 'test another field'
     F.extendOn(context, { include: 'anotherField', highlight: true })
     expectedResult.response.results[0].anotherField = 'test another field'
+    expectedResult.response.results[0].hit = {
+      _id: 'test-id',
+      field: 'test field',
+      anotherField: 'test another field'
+    }
     await resultsTest(context, [
       _.extend(expectedCalls[0], {
+        _source: {
+          includes: 'anotherField',
+        },
         sort: {
           _score: 'desc',
         },

--- a/test/example-types/results.js
+++ b/test/example-types/results.js
@@ -102,6 +102,7 @@ describe('results', () => {
     delete context.exclude
   })
   it('should highlight additionalFields if showOtherMatches is set', async () => {
+    schema.elasticsearch.highlight = { test: ['field'] }
     service[0].hits.hits[0].anotherField = 'test another field'
     F.extendOn(context, { showOtherMatches: true, include: 'anotherField', highlight: true })
     expectedResult.response.results[0].anotherField = 'test another field'
@@ -118,10 +119,24 @@ describe('results', () => {
         sort: {
           _score: 'desc',
         },
+        highlight: {
+          fields: {
+            field: {}
+          },
+          number_of_fragments: 0,
+          post_tags: [
+            "</b>"
+          ],
+          pre_tags: [
+            "<b>"
+          ],
+          require_field_match: false
+        }
       }),
     ])
   })
   it('should not highlight additionalFields if showOtherMatches is not set', async () => {
+    schema.elasticsearch.highlight = { test: ['field'] }
     service[0].hits.hits[0].anotherField = 'test another field'
     F.extendOn(context, { include: 'anotherField', highlight: true })
     expectedResult.response.results[0].anotherField = 'test another field'
@@ -138,6 +153,17 @@ describe('results', () => {
         sort: {
           _score: 'desc',
         },
+        highlight: {
+          fields: {},
+          number_of_fragments: 0,
+          post_tags: [
+            "</b>"
+          ],
+          pre_tags: [
+            "<b>"
+          ],
+          require_field_match: false
+        }
       }),
     ])
   })

--- a/test/example-types/results.js
+++ b/test/example-types/results.js
@@ -164,7 +164,7 @@ describe('results', () => {
     ])
   })
   it('should sort on "_score: desc" with no sortField config', () =>
-   resultsTest(context, [
+    resultsTest(context, [
       _.extend(expectedCalls[0], {
         sort: {
           _score: 'desc',

--- a/test/example-types/results.js
+++ b/test/example-types/results.js
@@ -21,7 +21,7 @@ describe('results', () => {
             {
               _id: 'test-id',
               field: 'test field',
-            },
+            }
           ],
         },
       },
@@ -69,9 +69,13 @@ describe('results', () => {
     ])
   })
 
-  it('should be able to filter fields with include', () => {
+  it('should be able to filter fields with include', async () => {
     F.extendOn(context, { include: 'field' })
-    resultsTest(context, [
+    expectedResult.response.results[0].hit = {
+      _id: 'test-id',
+      field: 'test field',
+    }
+    await resultsTest(context, [
       _.extend(expectedCalls[0], {
         _source: {
           includes: 'field',
@@ -82,11 +86,10 @@ describe('results', () => {
       }),
     ])
     delete context.include
-    return
   })
-  it('should be able to filter fields with exclude', () => {
+  it('should be able to filter fields with exclude', async () => {
     F.extendOn(context, { exclude: 'field' })
-    resultsTest(context, [
+    await resultsTest(context, [
       _.extend(expectedCalls[0], {
         _source: {
           excludes: 'field',
@@ -97,18 +100,16 @@ describe('results', () => {
       }),
     ])
     delete context.exclude
-    return
   })
-
-  it('should sort on "_score: desc" with no sortField config', () =>
-    resultsTest(context, [
+  it('should sort on "_score: desc" with no sortField config', async () =>
+    await resultsTest(context, [
       _.extend(expectedCalls[0], {
         sort: {
           _score: 'desc',
         },
       }),
     ]))
-  it('verbose should work', () => {
+  it('verbose should work', async () => {
     F.extendOn(context, { verbose: true })
     F.extendOn(expectedResult.response.results, [
       {
@@ -121,7 +122,7 @@ describe('results', () => {
         },
       },
     ])
-    return resultsTest(context, [
+    await resultsTest(context, [
       _.extend(expectedCalls[0], {
         sort: {
           _score: 'desc',
@@ -129,9 +130,9 @@ describe('results', () => {
       }),
     ])
   })
-  it('should order by sortDir config', () => {
+  it('should order by sortDir config', async () => {
     F.extendOn(context, { sortDir: 'asc' })
-    return resultsTest(context, [
+    await resultsTest(context, [
       _.extend(expectedCalls[0], {
         sort: {
           _score: 'asc',
@@ -139,10 +140,10 @@ describe('results', () => {
       }),
     ])
   })
-  it('should sort on sortField config', () => {
+  it('should sort on sortField config', async () => {
     let sortField = 'test.field'
     F.extendOn(context, { sortField })
-    return resultsTest(context, [
+    await  resultsTest(context, [
       _.extend(expectedCalls[0], {
         sort: {
           [context.sortField]: 'desc',
@@ -150,10 +151,10 @@ describe('results', () => {
       }),
     ])
   })
-  it('should strip ".untouched" from sortField config', () => {
+  it('should strip ".untouched" from sortField config', async () => {
     let sortField = 'test.field'
     F.extendOn(context, { sortField: `${sortField}.untouched` })
-    return resultsTest(context, [
+    await resultsTest(context, [
       _.extend(expectedCalls[0], {
         sort: {
           [sortField]: 'desc',
@@ -161,7 +162,7 @@ describe('results', () => {
       }),
     ])
   })
-  it('should add ".untouched" suffix from schema notAnalyzedField', () => {
+  it('should add ".untouched" suffix from schema notAnalyzedField', async () => {
     let sortField = 'test.field'
     F.extendOn(context, { sortField })
     F.extendOn(schema, {
@@ -173,7 +174,7 @@ describe('results', () => {
         },
       },
     })
-    return resultsTest(context, [
+    await resultsTest(context, [
       _.extend(expectedCalls[0], {
         sort: {
           [`${sortField}.untouched`]: 'desc',
@@ -181,10 +182,10 @@ describe('results', () => {
       }),
     ])
   })
-  it('should strip ".untouched" from sortField config when sortMode config is "word"', () => {
+  it('should strip ".untouched" from sortField config when sortMode config is "word"', async () => {
     let sortField = 'test.field'
     F.extendOn(context, { sortField, sortMode: 'word' })
-    return resultsTest(context, [
+    await resultsTest(context, [
       _.extend(expectedCalls[0], {
         sort: {
           [sortField]: 'desc',
@@ -192,10 +193,10 @@ describe('results', () => {
       }),
     ])
   })
-  it('should sort on sortField + ".untouched" when sortMode config is "field"', () => {
+  it('should sort on sortField + ".untouched" when sortMode config is "field"', async () => {
     let sortField = 'test.field'
     F.extendOn(context, { sortField, sortMode: 'field' })
-    return resultsTest(context, [
+    await resultsTest(context, [
       _.extend(expectedCalls[0], {
         sort: {
           [`${sortField}.untouched`]: 'desc',
@@ -203,11 +204,11 @@ describe('results', () => {
       }),
     ])
   })
-  it('forceExclude', () => {
+  it('forceExclude', async () => {
     F.extendOn(context, { forceExclude: true })
     let excludes = ['a', 'b', 'c']
     F.extendOn(schema, { forceExclude: excludes })
-    return resultsTest(context, [
+    await resultsTest(context, [
       _.extend(expectedCalls[0], {
         _source: {
           excludes,
@@ -218,21 +219,4 @@ describe('results', () => {
       }),
     ])
   })
-  // it.only('should populate', () => {
-  //   let sortField = 'test.field'
-  //   F.extendOn(context, { populate: {
-  //     test: {
-  //       localField: 'local',
-  //       foreignField: 'foreign',
-  //       schema: 'targetSchema'
-  //     }
-  //   } })
-  //   return resultsTest(context, [
-  //     _.extend(expectedCalls[0], {
-  //       sort: {
-  //         [`${sortField}.untouched`]: 'desc',
-  //       },
-  //     }),
-  //   ])
-  // })
 })

--- a/test/example-types/results.js
+++ b/test/example-types/results.js
@@ -164,7 +164,7 @@ describe('results', () => {
     ])
   })
   it('should sort on "_score: desc" with no sortField config', async () =>
-   resultsTest(context, [
+    resultsTest(context, [
       _.extend(expectedCalls[0], {
         sort: {
           _score: 'desc',

--- a/test/example-types/results.js
+++ b/test/example-types/results.js
@@ -101,6 +101,30 @@ describe('results', () => {
     ])
     delete context.exclude
   })
+  it('should highlight additionalFields if showOtherMatches is set', async () => {
+    service[0].hits.hits[0].anotherField = 'test another field'
+    F.extendOn(context, { showOtherMatches: true, include: 'anotherField', highlight: true })
+    expectedResult.response.results[0].anotherField = 'test another field'
+    await resultsTest(context, [
+      _.extend(expectedCalls[0], {
+        sort: {
+          _score: 'desc',
+        },
+      }),
+    ])
+  })
+  it('should not highlight additionalFields if showOtherMatches is not set', async () => {
+    service[0].hits.hits[0].anotherField = 'test another field'
+    F.extendOn(context, { include: 'anotherField', highlight: true })
+    expectedResult.response.results[0].anotherField = 'test another field'
+    await resultsTest(context, [
+      _.extend(expectedCalls[0], {
+        sort: {
+          _score: 'desc',
+        },
+      }),
+    ])
+  })
   it('should sort on "_score: desc" with no sortField config', async () =>
     await resultsTest(context, [
       _.extend(expectedCalls[0], {

--- a/test/example-types/results.js
+++ b/test/example-types/results.js
@@ -168,7 +168,7 @@ describe('results', () => {
     ])
   })
   it('should sort on "_score: desc" with no sortField config', async () =>
-    await resultsTest(context, [
+   resultsTest(context, [
       _.extend(expectedCalls[0], {
         sort: {
           _score: 'desc',


### PR DESCRIPTION
Fixes #117 

### Description
* restricts highlighting to context.includes unless context.showOtherMatches is set truthy