### PR TITLE
Add the inlineAliases highlighting support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.16.1
+# 0.17.0
 * Add support for "inlineAliases" when dealing with ES highlight response
 
 # 0.16.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.16.1
+* Add support for "inlineAliases" when dealing with ES highlight response
+
 # 0.16.0
 * Restrict results context highlighting to includes unless context.showOtherMatches
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -48,7 +48,7 @@ module.exports = {
         // intersect with context.include so we only highlight fields we specified in the context
         _.intersection(context.include),
         // concat the inlineAliases KEYS so they are part of the highlight.fields object so we highlight on them in the ES response
-        _.concat(_.values(inlineAliases)),
+        _.concat(_.values(inlineAliases))
       )(schema.elasticsearch.highlight)
 
       F.extendOn(result, {

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -46,9 +46,12 @@ module.exports = {
         _.concat(_.keys(inlineAliases)),
         _.uniq(),
         // intersect with context.include so we only highlight fields we specified in the context if showOtherMatches is set to false
-        fields => _.getOr(false, 'showOtherMatches', context) ? fields : _.intersection(context.include, fields),
+        fields =>
+          _.getOr(false, 'showOtherMatches', context)
+            ? fields
+            : _.intersection(context.include, fields),
         // concat the inlineAliases KEYS so they are part of the highlight.fields object so we highlight on them in the ES response
-        _.concat(_.values(inlineAliases)),
+        _.concat(_.values(inlineAliases))
       )(schema.elasticsearch.highlight)
 
       F.extendOn(result, {

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -34,20 +34,17 @@ module.exports = {
 
     if (highlight) {
       // Only take the fields that matter to highlighting which are the inline, inlineAliases and additionalFields sections
-      let schemaHiglightFields = _.flow(
+      let schemaHighlightFields = _.flow(
         _.pick(['inline', 'additionalFields']),
         _.values,
         _.flatten,
         _.concat(_.keys(inlineAliases)),
         _.uniq(),
-      )(schema.elasticsearch.highlight)
-
-      let highlightFields = _.flow(
         // intersect with context.include so we only highlight fields we specified in the context
         _.intersection(context.include),
         // concat the inlineAliases KEYS so they are part of the highlight.fields object so we highlight on them in the ES response
         _.concat(_.values(inlineAliases)),
-      )(schemaHiglightFields)
+      )(schema.elasticsearch.highlight)
 
       F.extendOn(result, {
         highlight: {
@@ -55,7 +52,7 @@ module.exports = {
           post_tags: ['</b>'],
           require_field_match: false,
           number_of_fragments: 0,
-          fields: _.fromPairs(_.map(val => [val, {}], highlightFields)),
+          fields: _.fromPairs(_.map(val => [val, {}], schemaHighlightFields)),
         },
       })
     }

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -45,10 +45,10 @@ module.exports = {
         _.flatten,
         _.concat(_.keys(inlineAliases)),
         _.uniq(),
-        // intersect with context.include so we only highlight fields we specified in the context
-        _.intersection(context.include),
+        // intersect with context.include so we only highlight fields we specified in the context if showOtherMatches is set to false
+        fields => _.getOr(false, 'showOtherMatches', context) ? fields : _.intersection(context.include, fields),
         // concat the inlineAliases KEYS so they are part of the highlight.fields object so we highlight on them in the ES response
-        _.concat(_.values(inlineAliases))
+        _.concat(_.values(inlineAliases)),
       )(schema.elasticsearch.highlight)
 
       F.extendOn(result, {

--- a/src/highlighting.js
+++ b/src/highlighting.js
@@ -65,12 +65,28 @@ function highlightResults(highlightFields, hit, pathToNested, include) {
   let mainHighlighted = false
   // Copy over all inline highlighted fields
   if (hit.highlight) {
-    _.each(highlightFields.inline, val => {
+    let { inline, inlineAliases } = highlightFields
+    // do the field replacement for the inline fields
+    _.each(inline, val => {
       if (hit.highlight[val]) {
         _.set(hit._source, val, hit.highlight[val][0])
         mainHighlighted = true
       }
     })
+    // do the field replacement for the inlineAliases fields
+    if (inlineAliases) {
+      for(let field in inlineAliases) {
+        let mapToField = inlineAliases[field]
+        // if we have a highlight result matching the inlineAliases TO field
+        if (hit.highlight[mapToField]) {
+          // if the field is only in inlineAliases OR it is in both but not inlined/highlighted already by the inline section
+          if(!_.includes(inline, field) || (_.includes(inline, field) && !hit.highlight[field])) {
+            _.set(hit._source, field, hit.highlight[mapToField][0])
+            mainHighlighted = true
+          }
+        }
+      }
+    }
   }
 
   return {

--- a/test/example-types/results.js
+++ b/test/example-types/results.js
@@ -124,9 +124,7 @@ describe('results', () => {
           _score: 'desc',
         },
         highlight: {
-          fields: {
-            field: {},
-          },
+          fields: {},
           number_of_fragments: 0,
           post_tags: ['</b>'],
           pre_tags: ['<b>'],

--- a/test/highlighting.js
+++ b/test/highlighting.js
@@ -1,7 +1,7 @@
 let highlighting = require('../src/highlighting')
 let { expect } = require('chai')
 
-describe.only('highlighting', () => {
+describe('highlighting', () => {
   describe('highlightResults', () => {
     it('should work with includes', () => {
       let highlightFields = { inline: ['title', 'description', 'summary'] }

--- a/test/highlighting.js
+++ b/test/highlighting.js
@@ -1,7 +1,7 @@
 let highlighting = require('../src/highlighting')
 let { expect } = require('chai')
 
-describe('highlighting', () => {
+describe.only('highlighting', () => {
   describe('highlightResults', () => {
     it('should work with includes', () => {
       let highlightFields = { inline: ['title', 'description', 'summary'] }
@@ -53,6 +53,73 @@ describe('highlighting', () => {
         highlight: { summary: ['a'], description: ['b'], title: ['c'] },
       }
       let result = highlighting.highlightResults(highlightFields, hit)
+      expect(result).to.deep.equal({
+        additionalFields: [],
+        mainHighlighted: true,
+      })
+    })
+    it('should work with inline', () => {
+      let highlightFields = {
+        inline: ['title', 'description'],
+      }
+      let hit = {
+        _source: {
+          title: '...',
+          description: '...'
+        },
+        highlight: { title: ['<a>foo</a>'], 'description': ['<a>bar</a>'] },
+      }
+      let result = highlighting.highlightResults(highlightFields, hit)
+      expect(hit._source).to.deep.equal({
+        title: '<a>foo</a>',
+        description: '<a>bar</a>'
+      })
+      expect(result).to.deep.equal({
+        additionalFields: [],
+        mainHighlighted: true,
+      })
+    })
+    it('should work with inlineAliases', () => {
+      let highlightFields = {
+        inline: ['title', 'description'],
+        inlineAliases: {
+          description: 'description.exact'
+        }
+      }
+      let hit = {
+        _source: {
+          title: '...',
+          description: '...'
+        },
+        highlight: { title: ['<a>foo</a>'], 'description.exact': ['<a>bar</a>'] },
+      }
+      let result = highlighting.highlightResults(highlightFields, hit)
+      expect(hit._source).to.deep.equal({
+        title: '<a>foo</a>',
+        description: '<a>bar</a>'
+      })
+      expect(result).to.deep.equal({
+        additionalFields: [],
+        mainHighlighted: true,
+      })
+    })
+    it('inline should precede inlineAliases', () => {
+      let highlightFields = {
+        inline: ['description'],
+        inlineAliases: {
+          description: 'description.exact'
+        }
+      }
+      let hit = {
+        _source: {
+          description: '...'
+        },
+        highlight: { description: ['<a>foo</a>'], 'description.exact': ['<a>bar</a>'] },
+      }
+      let result = highlighting.highlightResults(highlightFields, hit)
+      expect(hit._source).to.deep.equal({
+        description: '<a>foo</a>'
+      })
       expect(result).to.deep.equal({
         additionalFields: [],
         mainHighlighted: true,


### PR DESCRIPTION
inlineAliases allow for mapping of a field in the `hit._source` with the value of a field in ES response `highlight` object.