### PR TITLE
Throw message & error obj on client run exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.17.1
+* Throw error message and object on client search run exception
+
 # 0.17.0
 * Add support for "inlineAliases" when dealing with ES highlight response
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -90,6 +90,11 @@ let ElasticsearchProvider = (
       if (results.timed_out) context.timedout = true
       // Log response
       _.last(context._meta.requests).response = results
+    }).catch(({message, body}) => {
+      throw {
+        message,
+        ..._.get('error.caused_by', body)
+      }
     })
   },
   // Utility function to get a mapping used for building a schema directly from ES

--- a/test/example-types/geo.js
+++ b/test/example-types/geo.js
@@ -190,4 +190,16 @@ describe('geo', () => {
       Longitude: -80.1131784,
     })
   })
+  it('Should faild is no geoCodeLocation service is passed', () => {
+    let _geo = geoType()
+    let context = {
+      type: 'geo',
+      field: 'test',
+      location: 'SmartProcure',
+      radius: 10,
+      operator: 'within',
+      _meta: {},
+    }
+    return expect(Promise.resolve(_geo.filter(context))).to.throw
+  })
 })


### PR DESCRIPTION
Since we are in ES specific context make sure the error is streamlined and not the monolithic object that comes from ES by default. We mainly need the error message and the specific type it is.