### PR TITLE
Include variations fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.19.4
+* Include variations fix for highlighting
+
 # 0.19.3
 * Allow contexture search trees to override ES highlight section
 * Auto include in ES _.source.includes fields specified in the search highlight override

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -52,7 +52,7 @@ module.exports = {
         _.getOr({}, 'inlineAliases'),
         _.entries,
         _.filter(([k]) => _.includes(k, context.include)),
-        _.flatten,
+        _.flatten
       )(schemaHighlight)
 
       // Concat the search specific override fields with the schema `inline` so we have them as targets for highlight replacement
@@ -71,10 +71,10 @@ module.exports = {
         arrayToHighlightsFieldMap, // Convert the array to object map so we can simply _.pick again
         filtered =>
           showOtherMatches
-            // Highlight on all fields specified in the initial _.pick above.
-            ? filtered
-            // Only highlight on the fields listed in the context include section and their aliases (if any)
-            : _.pick(_.concat(context.include, schemaInlineAliases), filtered)
+            ? // Highlight on all fields specified in the initial _.pick above.
+              filtered
+            : // Only highlight on the fields listed in the context include section and their aliases (if any)
+              _.pick(_.concat(context.include, schemaInlineAliases), filtered)
       )(schemaHighlight)
 
       // Setup the DEFAULT highlight config object with the calculated fields above

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -48,7 +48,12 @@ module.exports = {
     if (schemaHighlight) {
       let showOtherMatches = _.getOr(false, 'showOtherMatches', context)
       let schemaInline = _.getOr([], 'inline', schemaHighlight)
-      let schemaInlineAliases = _.getOr({}, 'inlineAliases', schemaHighlight)
+      let schemaInlineAliases = _.flow(
+        _.getOr({}, 'inlineAliases'),
+        _.entries,
+        _.filter(([k]) => _.includes(k, context.include)),
+        _.flatten,
+      )(schemaHighlight)
 
       // Concat the search specific override fields with the schema `inline` so we have them as targets for highlight replacement
       schemaHighlight = _.set(
@@ -61,13 +66,15 @@ module.exports = {
         _.pick(['inline', 'additionalFields']), // Get the highlight fields we will be working with
         _.values,
         _.flatten,
-        _.concat(_.values(schemaInlineAliases)), // Include the provided field aliases if any
+        _.concat(schemaInlineAliases), // Include the provided field aliases if any
         _.uniq,
         arrayToHighlightsFieldMap, // Convert the array to object map so we can simply _.pick again
         filtered =>
           showOtherMatches
-            ? filtered // Highlight on all fields specified in the initial _.pick above
-            : _.pick(context.include, filtered) // Only highlight on the fields listed in the context include section
+            // Highlight on all fields specified in the initial _.pick above.
+            ? filtered
+            // Only highlight on the fields listed in the context include section and their aliases (if any)
+            : _.pick(_.concat(context.include, schemaInlineAliases), filtered)
       )(schemaHighlight)
 
       // Setup the DEFAULT highlight config object with the calculated fields above


### PR DESCRIPTION
- Makes sure that the `inlineAliases` are actually part of the final filtered fields on witch to actually highlight on. The issue was that `inlineAliases` ware filtered out.