### PR TITLE
Fix zero value handling in esTwoLevelAggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.19.5
+* TwoLevelAggregation: Fix bug where zero values were being treated as missing 
+
 # 0.19.4
 * Include variations fix for highlighting
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "0.19.4",
+  "version": "0.19.5",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/esTwoLevelAggregation.js
+++ b/src/example-types/esTwoLevelAggregation.js
@@ -71,13 +71,15 @@ module.exports = {
           (bucket, key) =>
             _.extend(
               {
-                // Generally bucket.key works, but for twoLevelMatch it needed to be key because buckets is an object and not an array
+                // Generally bucket.key works, but for twoLevelMatch it needed
+                // to be key because buckets is an object and not an array
                 key: bucket.key || key,
                 doc_count: bucket.doc_count,
               },
+              // If any one of the metrics in our bucket has a nil value, we
+              // pull that out instead of returning the whole bucket
               _.find(
-                value =>
-                  !F.cascade(['value', 'values'], value) && _.isObject(value),
+                x => _.isObject(x) && _.isNil(x.value) && _.isNil(x.values),
                 bucket
               ) ||
                 _.flow(

--- a/test/example-types/matchCardinality.js
+++ b/test/example-types/matchCardinality.js
@@ -20,6 +20,18 @@ describe('matchCardinality', () => {
                     value: 471,
                   },
                 },
+                succeed: {
+                  doc_count: 50,
+                  cardinality: {
+                    value: 0,
+                  },
+                },
+                retry: {
+                  doc_count: 50,
+                  cardinality: {
+                    value: null,
+                  },
+                },
               },
             },
           },
@@ -47,6 +59,16 @@ describe('matchCardinality', () => {
             key: 'fail',
             doc_count: 50,
             cardinality: 471,
+          },
+          {
+            key: 'succeed',
+            doc_count: 50,
+            cardinality: 0,
+          },
+          {
+            key: 'retry',
+            doc_count: 50,
+            value: null,
           },
         ],
       },


### PR DESCRIPTION
esTwoLevelAgg filters its buckets for metrics with falsy values (currently including zeros), and if it finds one it strips off a bunch of information from the result. I don't really understand this behavior, but I assume it's fine - we just don't want it to happen for zeros.

Since the twoLevelAgg type doesn't have any test cases of its own, I took advantage of the matchCardinality test case to illustrate zero/null handling. (Admittedly a weird choice, but It also shows that it happens with _any_ property with `{ value: null }` in a twoLevelAgg bucket, even cardinality.)