### PR TITLE
Feature/6298 date range facet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+
+# 0.23.2
+* dateRangeFacet changes - Add timeZone default value.
+
 # 0.23.1
 * dateRangeFacet changes for consistency with the facet type output.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/dateRangeFacet.js
+++ b/src/example-types/dateRangeFacet.js
@@ -49,12 +49,12 @@ module.exports = {
    * Ranges should have 'range' prop containing the range phrase (eg. 'allFutureDates')
    * Example:
       ranges: [
-        { range: 'allFutureDates', key: "open" },
-        { range: 'allPastDates', key: "expired" }
+        { range: 'allFutureDates', key: "Open" },
+        { range: 'allPastDates', key: "Expired" }
       ]
    */
   async result(context, search) {
-    let { field, format, timezone, ranges } = context
+    let { field, format, timezone = 'UTC', ranges } = context
     let counts = await search({
       aggs: {
         range: {


### PR DESCRIPTION
- Set `timezone` default for the `result` just like for the `filter`. `rollingRangeToDates` needs a timezone.
 