### PR TITLE
Elasticsearch 7 (and new elastic client) support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Get mappings now handles type-less mappings, which is the default on ES7+ (while still handling types for ES6-)
 * [DateRangeFacet] converted to `dateOptionalTime` format which works on ES 6 and 7
 * [Results] track_total_hits and handle total.hits being an object for ES 7 support
+* Remove `bluebird` dependency
 
 # 0.24.1
 * Added _score field to the results type

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.0.0
+* BREAKING: Assumes the elasticsearch client is the new @elastic/elasticsearch npm package. Will not work with the old `elasticsearch` package
+* BREAKING: Removed unused `getMappingProperties` API
+* Errors are now gracefully caught on a per node basis and properly set on node.error. This means that a node can throw an error, but the rest of the search will continue properly and also not log an uncaught exception to the console. This means the contexture dev tools can now be used to see raw ES errors.
+* Simplifed runSearch with modern JS syntax
+* Get mappings now handles type-less mappings, which is the default on ES7+ (while still handling types for ES6-)
+* [DateRangeFacet] converted to `dateOptionalTime` format which works on ES 6 and 7
+* [Results] track_total_hits and handle total.hits being an object for ES 7 support
 
 # 0.24.1
 * Added _score field to the results type

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   },
   "dependencies": {
     "@elastic/datemath": "^2.3.0",
-    "bluebird": "^3.5.0",
     "futil": "^1.67.0",
     "js-combinatorics": "^0.5.3",
     "json-stable-stringify": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "0.24.1",
+  "version": "1.0.0",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/dateRangeFacet.js
+++ b/src/example-types/dateRangeFacet.js
@@ -60,7 +60,7 @@ module.exports = {
         range: {
           date_range: {
             field,
-            format: format || "yyyy-MM-dd'T'HH:mm:ss.SSSZ",
+            format: format || 'dateOptionalTime',
             ranges: _.map(
               ({ range, key }) => ({
                 key,

--- a/src/example-types/geo.js
+++ b/src/example-types/geo.js
@@ -1,5 +1,4 @@
 let _ = require('lodash/fp')
-let Promise = require('bluebird')
 
 let geo = ({
   geocodeLocation = () => {

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -27,6 +27,7 @@ module.exports = {
         [sortField]: sortDir,
       },
       explain: context.explain,
+      // Without this, ES7+ stops counting at 10k instead of returning the actual count
       track_total_hits: true,
     }
 

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -27,7 +27,7 @@ module.exports = {
         [sortField]: sortDir,
       },
       explain: context.explain,
-      track_total_hits: true
+      track_total_hits: true,
     }
 
     if (context.forceExclude && _.isArray(schema.forceExclude))

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -27,6 +27,7 @@ module.exports = {
         [sortField]: sortDir,
       },
       explain: context.explain,
+      track_total_hits: true
     }
 
     if (context.forceExclude && _.isArray(schema.forceExclude))
@@ -106,7 +107,8 @@ module.exports = {
     return search(searchObj).then(results => ({
       scrollId: results._scroll_id,
       response: {
-        totalRecords: results.hits.total,
+        // ES 7+ is total.value, ES 6- is hits.total
+        totalRecords: F.getOrReturn('value', results.hits.total),
         startRecord: startRecord + 1,
         endRecord: startRecord + results.hits.hits.length,
         results: _.map(hit => {

--- a/src/example-types/smartIntervalHistogram.js
+++ b/src/example-types/smartIntervalHistogram.js
@@ -1,5 +1,4 @@
 let _ = require('lodash/fp')
-let Promise = require('bluebird')
 let statsResults = require('./statistical').result
 let calcSmartInterval = require('../smartInterval').calcSmartInterval
 

--- a/src/index.js
+++ b/src/index.js
@@ -52,9 +52,10 @@ let ElasticsearchProvider = (config = { request: {} }) => ({
     let client = config.getClient()
     // If we have a scrollId, use a different client API method
     let search = scrollId ? client.scroll : client.search
-    var response
+    let response
     try {
-      var { body: response } = await search(request, requestOptions)
+      let { body } = await search(request, requestOptions)
+      response = body
     } catch (e) {
       response = e
       node.error = e.meta.body

--- a/src/schema.js
+++ b/src/schema.js
@@ -23,15 +23,16 @@ let fromEsIndexMapping = _.mapValues(
     _.get('mappings'),
     // Always 1 type per index but sometimes there's a `_default_` type thing
     _.omit(['_default_']),
-    x => _.size(_.keys(x)) == 1
-      // 1 key implies es6 and below with types
-      ? _.flow(
-          _.toPairs,
-          // Capture esType
-          ([[type, fields]]) => ({ fields, elasticsearch: { type } })
-        )(x)
-      // More than one key seems like no types (es7+)
-      : ({ fields: x, elasticsearch: {} }),
+    x =>
+      _.size(_.keys(x)) == 1
+        ? // 1 key implies es6 and below with types
+          _.flow(
+            _.toPairs,
+            // Capture esType
+            ([[type, fields]]) => ({ fields, elasticsearch: { type } })
+          )(x)
+        : // More than one key seems like no types (es7+)
+          { fields: x, elasticsearch: {} },
     _.update(
       'fields',
       _.flow(
@@ -92,7 +93,9 @@ let getESSchemas = client =>
   Promise.all([
     client.indices.getMapping(),
     client.indices.getAlias(),
-  ]).then(([{body:mappings}, {body:aliases}]) => fromMappingsWithAliases(mappings, aliases))
+  ]).then(([{ body: mappings }, { body: aliases }]) =>
+    fromMappingsWithAliases(mappings, aliases)
+  )
 
 module.exports = {
   // flagFields,

--- a/src/schema.js
+++ b/src/schema.js
@@ -24,7 +24,7 @@ let fromEsIndexMapping = _.mapValues(
     // Always 1 type per index but sometimes there's a `_default_` type thing
     _.omit(['_default_']),
     x =>
-      _.size(_.keys(x)) == 1
+      _.size(_.keys(x)) === 1
         ? // 1 key implies es6 and below with types
           _.flow(
             _.toPairs,

--- a/src/schema.js
+++ b/src/schema.js
@@ -86,7 +86,7 @@ let getESSchemas = client =>
   Promise.all([
     client.indices.getMapping(),
     client.indices.getAlias(),
-  ]).then(([mappings, aliases]) => fromMappingsWithAliases(mappings, aliases))
+  ]).then(([{body:mappings}, {body:aliases}]) => fromMappingsWithAliases(mappings, aliases))
 
 module.exports = {
   // flagFields,

--- a/src/schema.js
+++ b/src/schema.js
@@ -23,9 +23,15 @@ let fromEsIndexMapping = _.mapValues(
     _.get('mappings'),
     // Always 1 type per index but sometimes there's a `_default_` type thing
     _.omit(['_default_']),
-    _.toPairs,
-    // Capture esType
-    ([[type, fields]]) => ({ fields, elasticsearch: { type } }),
+    x => _.size(_.keys(x)) == 1
+      // 1 key implies es6 and below with types
+      ? _.flow(
+          _.toPairs,
+          // Capture esType
+          ([[type, fields]]) => ({ fields, elasticsearch: { type } })
+        )(x)
+      // More than one key seems like no types (es7+)
+      : ({ fields: x, elasticsearch: {} }),
     _.update(
       'fields',
       _.flow(

--- a/test/example-types/results.js
+++ b/test/example-types/results.js
@@ -60,6 +60,7 @@ describe('results', () => {
         from: 0,
         size: 10,
         explain: false,
+        track_total_hits: true,
       },
     ]
     resultsTest = _.partial(sequentialResultTest, [

--- a/test/example-types/testUtils.js
+++ b/test/example-types/testUtils.js
@@ -1,6 +1,5 @@
 const chai = require('chai')
 const sinon = require('sinon')
-const Promise = require('bluebird')
 const F = require('futil')
 const _ = require('lodash/fp')
 const sinonChai = require('sinon-chai')


### PR DESCRIPTION
Fixes #128 

* BREAKING: Assumes the elasticsearch client is the new @elastic/elasticsearch npm package. Will not work with the old `elasticsearch` package
* BREAKING: Removed unused `getMappingProperties` API
* Errors are now gracefully caught on a per node basis and properly set on node.error. This means that a node can throw an error, but the rest of the search will continue properly and also not log an uncaught exception to the console. This means the contexture dev tools can now be used to see raw ES errors.
* Simplifed runSearch with modern JS syntax
* Get mappings now handles type-less mappings, which is the default on ES7+ (while still handling types for ES6-)
* [DateRangeFacet] converted to `dateOptionalTime` format which works on ES 6 and 7
* [Results] track_total_hits and handle total.hits being an object for ES 7 support
* Remove `bluebird` dependency
