### PR TITLE
Geo fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.0.3
+* [geo] Fixed bug with client passed latitude/longitude
+
 # 1.0.2
 * [number] Fix additional bug with `findBestRange` (map result keys to number)
 
@@ -70,6 +73,8 @@
     * Killed useless `caseSensitive` flag
   * [Text]
     * Killed useless `caseSensitive` flag
+  * [Geo]
+    * Killed deprecated server-side `geocodeLocation` function
   * [DateHistogram]
     * Killed unused `minDate` and `maxDate` on response
     * Killed unused extendedBounds support

--- a/README.md
+++ b/README.md
@@ -119,27 +119,17 @@ Output
 ```
 
 #### `geo`
-Represents a geographic radius search. Needs a geocodeLocation service passed in to it. Currently assumes it is a HERE maps geocoder search.
+Represents a geographic radius search. Requires geocoding on the client before passing up.
 
 Input
 
 | Name            | Type                            | Default           | Description |
 | ----            | ----                            | -------           | ----------- |
 | `field`         | string                          | None, *required*  | The field it's operating on |
-| `location`      | string                          | None, *required*  | Location to geocode (e.g. an address, businessname, anything the google geocode can take) |
+| `latitude`      | number/string                   | None, *required*  | Latitude |
+| `longitude`     | number/string                   | None, *required*  | Longitude |
 | `radius`        | number                          | None, *required*  | Radius in miles |
 | `operator`      | `within`/`not within`           | within            | Whether the filter forces inclusion or exclusion |
-
-Output
-
-```js
-{
-  Latitude: Number
-  Longitude: Number
-}
-```
-
-The result can be used to show what location the server on a map, though in practice it's usually better to geocode on the client. This type is planned to be extended to support passing along raw lat/lng.
 
 #### `dateRangeFacet`
 dateRangeFacet is like a `facet` but the options correspond to named date range buckets

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/filters/geo.js
+++ b/src/example-types/filters/geo.js
@@ -1,4 +1,3 @@
-let _ = require('lodash/fp')
 let { negate } = require('../../utils/elasticDSL')
 
 module.exports = {

--- a/src/example-types/filters/geo.js
+++ b/src/example-types/filters/geo.js
@@ -1,34 +1,16 @@
 let _ = require('lodash/fp')
 let { negate } = require('../../utils/elasticDSL')
 
-let hasValue = ({ location, latitude, longitude, radius, operator }) =>
-  !!((location || (latitude && longitude)) && radius && operator)
-
-let geo = ({
-  geocodeLocation = () => {
-    throw new Error('Geo filter was not passed a geocode service')
-  },
-} = {}) => ({
-  hasValue,
-  validContext: hasValue,
-  async filter(node) {
-    if (node.latitude && node.longitude)
-      return { Latitude: node.latitude, Longitude: node.longitude }
-    try {
-      let response = await geocodeLocation(node.location)
-      node._meta.preprocessorResult = response
-      let result = {
-        geo_distance: {
-          [node.field]: `${response.Latitude},${response.Longitude}`,
-          distance: `${node.radius}mi`,
-        },
-      }
-      return node.operator !== 'within' ? negate(result) : result
-    } catch (err) {
-      console.error('An error occured within the geo provider: ', err)
+module.exports = {
+  hasValue: ({ latitude, longitude, radius, operator }) =>
+    !!(latitude && longitude && radius && operator),
+  filter: ({ field, latitude, longitude, radius, operator }) => {
+    let filter = {
+      geo_distance: {
+        [field]: [longitude, latitude],
+        distance: `${radius}mi`,
+      },
     }
+    return operator === 'within' ? filter : negate(filter)
   },
-  result: _.get('_meta.preprocessorResult'),
-})
-
-module.exports = geo
+}

--- a/test/example-types/filters/geo.js
+++ b/test/example-types/filters/geo.js
@@ -1,203 +1,62 @@
-const geoType = require('../../../src/example-types/filters/geo')
+const geo = require('../../../src/example-types/filters/geo')
 const utils = require('../testUtils')
 let { expect } = require('chai')
-let chai = require('chai')
-let chaiAsPromised = require('chai-as-promised')
-chai.use(chaiAsPromised)
 
 describe('geo', () => {
-  let geo = geoType({
-    geocodeLocation: () => ({
-      Latitude: 26.3170479,
-      Longitude: -80.1131784,
-    }),
-  })
-
   it('hasValue should work', () => {
     utils.hasValueContexts(geo)([
-      {
-        location: true,
-        radius: true,
-        operator: true,
-      },
-      {
-        location: true,
-        radius: -1,
-        operator: true,
-      },
-      {
-        location: 'SmartProcure',
-        radius: 10,
-        operator: 'within',
-      },
+      { latitude: 26, longitude: -80, radius: true, operator: true },
+      { latitude: 26, longitude: -80, radius: -1, operator: true },
+      { latitude: 26, longitude: -80, radius: 10, operator: 'within' },
     ])
     utils.noValueContexts(geo)([
       {},
-      {
-        location: false,
-        radius: 10,
-        operator: 'within',
-      },
-      {
-        location: '',
-        radius: 10,
-        operator: 'within',
-      },
-      {
-        radius: 10,
-        operator: 'within',
-      },
-      {
-        location: true,
-        radius: 0,
-        operator: 'within',
-      },
-      {
-        location: true,
-        radius: false,
-        operator: 'within',
-      },
-      {
-        location: true,
-        operator: 'within',
-      },
-      {
-        location: true,
-        radius: 10,
-        operator: false,
-      },
-      {
-        location: true,
-        radius: 10,
-        operator: '',
-      },
-      {
-        location: true,
-        radius: 10,
-      },
+      { location: false, radius: 10, operator: 'within' },
+      { latitude: 26.3170479, radius: 10, operator: 'within' },
+      { radius: 10, operator: 'within' },
+      { latitude: 26, longitude: -80, radius: 0, operator: 'within' },
+      { latitude: 26, longitude: -80, radius: false, operator: 'within' },
+      { latitude: 26, longitude: -80, operator: 'within' },
+      { latitude: 26, longitude: -80, radius: 10, operator: false },
+      { latitude: 26, longitude: -80, radius: 10, operator: '' },
+      { latitude: 26, longitude: -80, radius: 10 },
     ])
   })
 
   describe('filter', () => {
-    it('should filter properly', () => {
+    it('should filter properly', async () => {
       expect(
-        geo.filter({
+        await geo.filter({
           type: 'geo',
           field: 'test',
-          location: 'SmartProcure',
+          latitude: 26.3170479,
+          longitude: -80.1131784,
           radius: 10,
           operator: 'within',
           _meta: {},
         })
-      ).to.become({
-        geo_distance: {
-          test: '26.3170479,-80.1131784',
-          distance: '10mi',
-        },
+      ).to.deep.equal({
+        geo_distance: { test: [-80.1131784, 26.3170479], distance: '10mi' },
       })
     })
-    it('should filter properly outside', () => {
+    it('should filter properly outside', async () => {
       expect(
-        geo.filter({
+        await geo.filter({
           type: 'geo',
           field: 'test',
-          location: 'SmartProcure',
+          latitude: 26.3170479,
+          longitude: -80.1131784,
           radius: 15,
           operator: 'outside',
           _meta: {},
         })
-      ).to.eventually.deep.equal({
+      ).to.deep.equal({
         bool: {
           must_not: {
-            geo_distance: {
-              test: '26.3170479,-80.1131784',
-              distance: '15mi',
-            },
+            geo_distance: { test: [-80.1131784, 26.3170479], distance: '15mi' },
           },
         },
       })
     })
-  })
-
-  it('validContext should work', () => {
-    utils.validContexts(geo)([
-      {
-        location: true,
-        radius: 1,
-        operator: true,
-      },
-      {
-        location: 'SmartProcure',
-        radius: 10,
-        operator: 'within',
-      },
-    ])
-    utils.noValidContexts(geo)([
-      {},
-      {
-        location: false,
-        radius: 10,
-        operator: 'within',
-      },
-      {
-        location: '',
-        radius: 10,
-        operator: 'within',
-      },
-      {
-        radius: 10,
-        operator: 'within',
-      },
-      {
-        location: true,
-        radius: 0,
-        operator: 'within',
-      },
-      {
-        location: true,
-        operator: 'within',
-      },
-      {
-        location: true,
-        radius: 10,
-        operator: false,
-      },
-      {
-        location: true,
-        radius: 10,
-        operator: '',
-      },
-      {
-        location: true,
-        radius: 10,
-      },
-    ])
-  })
-
-  it('result should work', () => {
-    let node = {
-      type: 'geo',
-      field: 'test',
-      location: 'SmartProcure',
-      radius: 10,
-      operator: 'within',
-      _meta: {},
-    }
-    return expect(geo.filter(node).then(() => geo.result(node))).to.become({
-      Latitude: 26.3170479,
-      Longitude: -80.1131784,
-    })
-  })
-  it('Should faild is no geoCodeLocation service is passed', () => {
-    let _geo = geoType()
-    let node = {
-      type: 'geo',
-      field: 'test',
-      location: 'SmartProcure',
-      radius: 10,
-      operator: 'within',
-      _meta: {},
-    }
-    return expect(Promise.resolve(_geo.filter(node))).to.throw
   })
 })


### PR DESCRIPTION
Fun fact: I thought this was broken in prod, because [I broke this in on August 6, 2020](https://github.com/smartprocure/contexture-elasticsearch/commit/b73b437bcdbb3d71fd3d0a25ba3f5fdba75cc335) - but it never made it out because that's just how long the v1 branch was open 😲 

This PR overhauls the geo filter to fix the bug introduced by v1 (and that commit) and also removes all of the unused legacy serverside geocodeLocation stuff. Technically, this is a breaking change and could have been v2, but I snuck it into the changelog for v1 because it should have been there in v1 😅  Since v1 is so fresh (and hasn't made it actual prod in our app, so I'm sure it's not in prod elsewhere), this seemed safe.