### PR TITLE
feature/162 - add tag counts to tagsQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.1.0
+* [tagsQuery] Return counts for each tag
+
 # 1.0.3
 * [geo] Fixed bug with client passed latitude/longitude
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/filters/tagsQuery.js
+++ b/src/example-types/filters/tagsQuery.js
@@ -87,13 +87,12 @@ let result = async (node, search) => {
     aggs: {
       tags: {
         filters: {
-          filters: F.arrayToObject(
-            _.get('word'),
-            tag => ({ match: { [field]: tag.word } })
-          )(tags)
-        }
-      }
-    }
+          filters: F.arrayToObject(_.get('word'), tag => ({
+            match: { [field]: tag.word },
+          }))(tags),
+        },
+      },
+    },
   }
 
   return _.flow(

--- a/src/example-types/filters/tagsQuery.js
+++ b/src/example-types/filters/tagsQuery.js
@@ -86,7 +86,7 @@ let result = async (node, search, schema, { options, getProvider }) => {
     return null
   }
 
-  let provider = getPriovider(node)
+  let provider = getProvider(node)
 
   let results = await Promise.all(
     _.map(

--- a/src/example-types/filters/tagsQuery.js
+++ b/src/example-types/filters/tagsQuery.js
@@ -85,20 +85,32 @@ let result = async ({ tags, join, field, exact, maxToCount = 20 }, search) => {
     return null
   }
 
-  let results = await Promise.all(_.map(async tag => ({ tag, result: await search({
-    query: {
-      query_string: {
-        query: tagsToQueryString([tag], join),
-        default_operator: 'AND',
-        default_field: field.replace('.untouched', '') + (exact ? '.exact' : ''),
-        ...(exact && { analyzer: 'exact' }),
-      },
-    },
-    size: 0,
-    track_total_hits: true
-  }) }), tags))
+  let results = await Promise.all(
+    _.map(
+      async tag => ({
+        tag,
+        result: await search({
+          query: {
+            query_string: {
+              query: tagsToQueryString([tag], join),
+              default_operator: 'AND',
+              default_field:
+                field.replace('.untouched', '') + (exact ? '.exact' : ''),
+              ...(exact && { analyzer: 'exact' }),
+            },
+          },
+          size: 0,
+          track_total_hits: true,
+        }),
+      }),
+      tags
+    )
+  )
 
-  return _.map(({ tag, result }) => ({ ...tag, count: _.get('hits.total.value', result) }), results)
+  return _.map(
+    ({ tag, result }) => ({ ...tag, count: _.get('hits.total.value', result) }),
+    results
+  )
 }
 
 module.exports = {
@@ -112,5 +124,5 @@ module.exports = {
   hasValue,
   filter,
   validContext: node => node.tags.length,
-  result
+  result,
 }

--- a/src/example-types/filters/tagsQuery.js
+++ b/src/example-types/filters/tagsQuery.js
@@ -80,7 +80,7 @@ let filter = ({ tags, join, field, exact }) => ({
   },
 })
 
-let result = async ({ tags, join, field, exact, maxToCount = 20 }, search) => {
+let result = async ({ tags, join, field, exact, _meta, maxToCount = 20 }, search) => {
   if (_.size(tags) > maxToCount) {
     return null
   }
@@ -98,6 +98,7 @@ let result = async ({ tags, join, field, exact, maxToCount = 20 }, search) => {
                 field.replace('.untouched', '') + (exact ? '.exact' : ''),
               ...(exact && { analyzer: 'exact' }),
             },
+            ...(_meta.relevantFilters ? _meta.relevantFilters : {}),
           },
           size: 0,
           track_total_hits: true,

--- a/src/example-types/filters/tagsQuery.js
+++ b/src/example-types/filters/tagsQuery.js
@@ -85,7 +85,7 @@ let result = async ({ tags, join, field, exact, maxToCount = 10 }, search) => {
     return null
   }
 
-  let results = await Promise.all(_.map(async tag => ({ tag, result: search({
+  let results = await Promise.all(_.map(async tag => ({ tag, result: await search({
     query_string: {
       query: tagsToQueryString([tag], join),
       default_operator: 'AND',

--- a/src/example-types/filters/tagsQuery.js
+++ b/src/example-types/filters/tagsQuery.js
@@ -80,22 +80,22 @@ let filter = ({ tags, join, field, exact }) => ({
   },
 })
 
-let result = async (node, search) => {
-  let { tags, field } = node
-
-  let aggs = {
-    aggs: {
-      tags: {
-        filters: {
-          filters: F.arrayToObject(
-            _.get('word'),
-            tag => filter({ ...node, tags: [tag] }),
-            tags
-          ),
-        },
+let buildResultQuery = node => ({
+  aggs: {
+    tags: {
+      filters: {
+        filters: F.arrayToObject(
+          _.get('word'),
+          tag => filter({ ...node, tags: [tag] }),
+          node.tags
+        ),
       },
     },
-  }
+  },
+})
+
+let result = async (node, search) => {
+  let aggs = buildResultQuery(node)
 
   return _.flow(
     _.get('aggregations.tags.buckets'),
@@ -114,5 +114,6 @@ module.exports = {
   hasValue,
   filter,
   validContext: _.flow(_.get('tags'), _.size),
+  buildResultQuery,
   result,
 }

--- a/src/example-types/filters/tagsQuery.js
+++ b/src/example-types/filters/tagsQuery.js
@@ -99,7 +99,8 @@ let result = async (node, search) => {
 
   return _.flow(
     _.get('aggregations.tags.buckets'),
-    _.mapValues(_.get('doc_count'))
+    _.mapValues(_.get('doc_count')),
+    results => ({ results })
   )(await search(aggs))
 }
 

--- a/test/example-types/filters/tagsQuery.js
+++ b/test/example-types/filters/tagsQuery.js
@@ -210,6 +210,7 @@ describe('filter', () => {
     expect(
       await result(
         {
+          field: 'baz',
           tags: [{ word: 'foo' }, { word: 'bar' }],
         },
         _.constant({

--- a/test/example-types/filters/tagsQuery.js
+++ b/test/example-types/filters/tagsQuery.js
@@ -8,6 +8,7 @@ let {
   tagsToQueryString,
   hasValue,
   filter,
+  result
 } = require('../../../src/example-types/filters/tagsQuery')
 
 let { expect } = require('chai')
@@ -202,6 +203,19 @@ describe('filter', () => {
         default_field: 'titleAndDescription.exact',
         analyzer: 'exact',
       },
+    })
+  })
+  it('result should query tag counts', () => {
+    console.log(result({
+      tags: [{ word: 'foo' }, { word: 'bar' }],
+    }))
+
+    expect (
+      result({
+        tags: [{ word: 'foo' }, { word: 'bar' }],
+      })
+    ).to.deep.equal({
+
     })
   })
 })

--- a/test/example-types/filters/tagsQuery.js
+++ b/test/example-types/filters/tagsQuery.js
@@ -256,6 +256,6 @@ describe('filter', () => {
           },
         })
       )
-    ).to.deep.equal({ foo: 2, bar: 5 })
+    ).to.deep.equal({ results: { foo: 2, bar: 5 } })
   })
 })

--- a/test/example-types/filters/tagsQuery.js
+++ b/test/example-types/filters/tagsQuery.js
@@ -10,7 +10,7 @@ let {
   filter,
   result
 } = require('../../../src/example-types/filters/tagsQuery')
-let _ = require('lodash')
+let _ = require('lodash/fp')
 
 let { expect } = require('chai')
 

--- a/test/example-types/filters/tagsQuery.js
+++ b/test/example-types/filters/tagsQuery.js
@@ -8,7 +8,7 @@ let {
   tagsToQueryString,
   hasValue,
   filter,
-  result
+  result,
 } = require('../../../src/example-types/filters/tagsQuery')
 let _ = require('lodash/fp')
 
@@ -207,11 +207,22 @@ describe('filter', () => {
     })
   })
   it('result should query tag counts', async () => {
-    expect(await result({
-      tags: [{ word: 'foo' }, { word: 'bar' }],
-    }, _.constant({ aggregations: { tags: { buckets: {
-      foo: { doc_count: 2 },
-      bar: { doc_count: 5}
-    }}} }))).to.deep.equal({ foo: 2, bar: 5 })
+    expect(
+      await result(
+        {
+          tags: [{ word: 'foo' }, { word: 'bar' }],
+        },
+        _.constant({
+          aggregations: {
+            tags: {
+              buckets: {
+                foo: { doc_count: 2 },
+                bar: { doc_count: 5 },
+              },
+            },
+          },
+        })
+      )
+    ).to.deep.equal({ foo: 2, bar: 5 })
   })
 })

--- a/test/example-types/filters/tagsQuery.js
+++ b/test/example-types/filters/tagsQuery.js
@@ -8,6 +8,7 @@ let {
   tagsToQueryString,
   hasValue,
   filter,
+  buildResultQuery,
   result,
 } = require('../../../src/example-types/filters/tagsQuery')
 let _ = require('lodash/fp')
@@ -204,6 +205,40 @@ describe('filter', () => {
         default_field: 'titleAndDescription.exact',
         analyzer: 'exact',
       },
+    })
+  })
+  it('buildResultQuery should construct correct agg', () => {
+    let node = {
+      tags: [
+        { word: 'foo' },
+        { word: 'bar' }
+      ],
+      field: 'baz',
+      join: 'and'
+    }
+    expect(buildResultQuery(node)).to.deep.equal({
+      "aggs": {
+        "tags": {
+          "filters": {
+            "filters": {
+              "foo": {
+                "query_string": {
+                  "query": "foo",
+                  "default_operator": "AND",
+                  "default_field": "baz"
+                }
+              },
+              "bar": {
+                "query_string": {
+                  "query": "bar",
+                  "default_operator": "AND",
+                  "default_field": "baz"
+                }
+              }
+            }
+          }
+        }
+      }
     })
   })
   it('result should query tag counts', async () => {

--- a/test/example-types/filters/tagsQuery.js
+++ b/test/example-types/filters/tagsQuery.js
@@ -209,36 +209,33 @@ describe('filter', () => {
   })
   it('buildResultQuery should construct correct agg', () => {
     let node = {
-      tags: [
-        { word: 'foo' },
-        { word: 'bar' }
-      ],
+      tags: [{ word: 'foo' }, { word: 'bar' }],
       field: 'baz',
-      join: 'and'
+      join: 'and',
     }
     expect(buildResultQuery(node)).to.deep.equal({
-      "aggs": {
-        "tags": {
-          "filters": {
-            "filters": {
-              "foo": {
-                "query_string": {
-                  "query": "foo",
-                  "default_operator": "AND",
-                  "default_field": "baz"
-                }
+      aggs: {
+        tags: {
+          filters: {
+            filters: {
+              foo: {
+                query_string: {
+                  query: 'foo',
+                  default_operator: 'AND',
+                  default_field: 'baz',
+                },
               },
-              "bar": {
-                "query_string": {
-                  "query": "bar",
-                  "default_operator": "AND",
-                  "default_field": "baz"
-                }
-              }
-            }
-          }
-        }
-      }
+              bar: {
+                query_string: {
+                  query: 'bar',
+                  default_operator: 'AND',
+                  default_field: 'baz',
+                },
+              },
+            },
+          },
+        },
+      },
     })
   })
   it('result should query tag counts', async () => {

--- a/test/example-types/filters/tagsQuery.js
+++ b/test/example-types/filters/tagsQuery.js
@@ -10,6 +10,7 @@ let {
   filter,
   result
 } = require('../../../src/example-types/filters/tagsQuery')
+let _ = require('lodash')
 
 let { expect } = require('chai')
 
@@ -205,17 +206,12 @@ describe('filter', () => {
       },
     })
   })
-  it('result should query tag counts', () => {
-    console.log(result({
+  it('result should query tag counts', async () => {
+    expect(await result({
       tags: [{ word: 'foo' }, { word: 'bar' }],
-    }))
-
-    expect (
-      result({
-        tags: [{ word: 'foo' }, { word: 'bar' }],
-      })
-    ).to.deep.equal({
-
-    })
+    }, _.constant({ aggregations: { tags: { buckets: {
+      foo: { doc_count: 2 },
+      bar: { doc_count: 5}
+    }}} }))).to.deep.equal({ foo: 2, bar: 5 })
   })
 })


### PR DESCRIPTION
FIxes #162 

### Description
* runs search for each tag and returns counts suitable with which to mark up the tags