### PR TITLE
Fix bug, contexture error response being omitted from thrown error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.1.2
+* Elasticsearch error response being omitted from thrown error. This was intended to be refactored as part of v1 but was never completed. This change brings back the previous behavior until the refactor is able to be completed.
+
 # 1.1.1
 * [results] Respect `highlight: false` to opt out highlighting (regression from 1.0)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,7 @@ let ElasticsearchProvider = (config = { request: {} }) => ({
       node.error = e.meta.body.error
       throw {
         message: `${e}`,
-        ...(e.meta.body.error)
+        ...e.meta.body.error,
       }
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,11 @@ let ElasticsearchProvider = (config = { request: {} }) => ({
       response = body
     } catch (e) {
       response = e
-      node.error = e.meta.body
+      node.error = e.meta.body.error
+      throw {
+        message: `${e}`,
+        ...(e.meta.body.error)
+      }
     }
 
     // Log Request


### PR DESCRIPTION
This was something that was intended to be refactored as part of v1 but was never
completed. This change brings back the previous behavior until the refactor is
able to be completed.