### PR TITLE
Increased the scroll value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.1.3
+* Increased the value of `scroll` from `'2m'` to `'60m'`, this is to accommodate deeper pagination. Eventually we need to move `search_after` as it is now recommended for es7 but for, but this change accommodates our use cases for now without (hopefully) too much of a performance hit.
+
 # 1.1.2
 * Elasticsearch error response being omitted from thrown error. This was intended to be refactored as part of v1 but was never completed. This change brings back the previous behavior until the refactor is able to be completed.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ let ElasticsearchProvider = (config = { request: {} }) => ({
     let { scroll, scrollId } = node
     let request = scrollId
       ? // If we have scrollId then keep scrolling, no query needed
-        { scroll: scroll === true ? '2m' : scroll, scrollId }
+        { scroll: scroll === true ? '60m' : scroll, scrollId }
       : // Deterministic ordering of JSON keys for request cache optimization
         stableKeys({
           index: schema.elasticsearch.index,


### PR DESCRIPTION
This is a quick fix solution to an issue where the count associated with results will be different than the number of results that are scrolled through. The root cause of the issue has to do with deep-pagination and the size of the value assigned to`scroll` (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#scroll-search-results)).

After this, we should start transitioning away from `scrollid` and start making use of `search_after` and point in time `pit`. But that requires more research around the use of the mechanism for smaller paginations and (less than 10,000) vs larger ones. 