### PR TITLE
Small example types fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.8
+* Example types' context is now valid even if `statsField` is not passed.
+* [fieldValuePartitionGroupStats] Use `getField` to map field to its un-analyzed value.
+
 # 1.1.7
 * [tagsText/text] Use `prefix` queries where possible for startsWith instead of regex
 * [tagsText/text] Support dynamic notAnalyzed field detection (no longer hardcoded to untouched)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/metricGroups/dateIntervalGroupStats.js
+++ b/src/example-types/metricGroups/dateIntervalGroupStats.js
@@ -11,7 +11,7 @@ let buildQuery = ({ groupField, statsField, stats, interval = 'year' }) => ({
 
 module.exports = {
   buildQuery,
-  validContext: node => node.groupField && node.statsField,
+  validContext: node => node.groupField,
   async result(node, search) {
     let response = await search(buildQuery(node))
     return { results: simplifyBuckets(response.aggregations.groups.buckets) }

--- a/src/example-types/metricGroups/fieldValuePartitionGroupStats.js
+++ b/src/example-types/metricGroups/fieldValuePartitionGroupStats.js
@@ -1,12 +1,15 @@
 let F = require('futil')
 let { statsAggs, simplifyBuckets } = require('../../utils/elasticDSL')
+let { getField } = require('../../utils/fields')
 
-let buildQuery = ({ statsField, stats, groupField, matchValue }) => ({
+let buildQuery = ({ statsField, stats, groupField, matchValue }, schema) => ({
   aggs: {
     groups: {
       filters: {
         other_bucket_key: 'fail',
-        filters: { pass: { term: { [groupField]: matchValue } } },
+        filters: {
+          pass: { term: { [getField(schema, groupField)]: matchValue } },
+        },
       },
       ...statsAggs(statsField, stats),
     },
@@ -15,9 +18,9 @@ let buildQuery = ({ statsField, stats, groupField, matchValue }) => ({
 
 module.exports = {
   buildQuery,
-  validContext: node => node.groupField && node.statsField,
-  async result(node, search) {
-    let response = await search(buildQuery(node))
+  validContext: node => node.groupField,
+  async result(node, search, schema) {
+    let response = await search(buildQuery(node, schema))
     return {
       results: simplifyBuckets(
         F.unkeyBy('key', response.aggregations.groups.buckets)

--- a/src/example-types/metricGroups/fieldValuesGroupStats.js
+++ b/src/example-types/metricGroups/fieldValuesGroupStats.js
@@ -41,7 +41,7 @@ let buildQuery = (node, schema) => {
 
 module.exports = {
   buildQuery,
-  validContext: node => node.groupField && node.statsField,
+  validContext: node => node.groupField,
   async result(node, search, schema) {
     let response = await search(buildQuery(node, schema))
     return {

--- a/src/example-types/metricGroups/numberIntervalGroupStats.js
+++ b/src/example-types/metricGroups/numberIntervalGroupStats.js
@@ -21,7 +21,7 @@ let buildQuery = async (node, getStats) => {
 
 module.exports = {
   buildQuery,
-  validContext: node => node.groupField && node.statsField,
+  validContext: node => node.groupField,
   async result(node, search) {
     let response = await search(await buildQuery(node, getStats(search)))
     return { results: simplifyBuckets(response.aggregations.groups.buckets) }

--- a/src/example-types/metricGroups/numberRangesGroupStats.js
+++ b/src/example-types/metricGroups/numberRangesGroupStats.js
@@ -11,7 +11,7 @@ let buildQuery = ({ groupField: field, statsField, stats, ranges }) => ({
 
 module.exports = {
   buildQuery,
-  validContext: node => node.groupField && node.statsField && node.ranges,
+  validContext: node => node.groupField && node.ranges,
   async result(node, search) {
     let response = await search(buildQuery(node))
     return { results: simplifyBuckets(response.aggregations.groups.buckets) }

--- a/src/example-types/metricGroups/percentilesGroupStats.js
+++ b/src/example-types/metricGroups/percentilesGroupStats.js
@@ -28,7 +28,7 @@ let buildQuery = async (node, getStats) => {
 
 module.exports = {
   buildQuery,
-  validContext: node => node.groupField && node.statsField,
+  validContext: node => node.groupField,
   async result(node, search) {
     let response = await search(await buildQuery(node, getStats(search)))
     return { results: simplifyBuckets(response.aggregations.groups.buckets) }

--- a/test/example-types/metricGroups/fieldValuePartitionGroupStats.js
+++ b/test/example-types/metricGroups/fieldValuePartitionGroupStats.js
@@ -2,17 +2,21 @@ let {
   buildQuery,
 } = require('../../../src/example-types/metricGroups/fieldValuePartitionGroupStats')
 let { expect } = require('chai')
+let { testSchema } = require('../testUtils')
 
 describe('fieldValuePartitionGroupStats', () => {
   it('should buildQuery', () => {
     expect(
-      buildQuery({
-        key: 'test',
-        type: 'fieldValuePartitionGroupStats',
-        groupField: 'Vendor.City.untouched',
-        statsField: 'LineItem.TotalPrice',
-        matchValue: 'Washington',
-      })
+      buildQuery(
+        {
+          key: 'test',
+          type: 'fieldValuePartitionGroupStats',
+          groupField: 'Vendor.City',
+          statsField: 'LineItem.TotalPrice',
+          matchValue: 'Washington',
+        },
+        testSchema('Vendor.City')
+      )
     ).to.eql({
       aggs: {
         groups: {
@@ -34,14 +38,17 @@ describe('fieldValuePartitionGroupStats', () => {
   })
   it('should buildQuery for cardinality', () => {
     expect(
-      buildQuery({
-        key: 'test',
-        type: 'fieldValuePartitionGroupStats',
-        groupField: 'Vendor.City.untouched',
-        statsField: 'LineItem.TotalPrice',
-        matchValue: 'Washington',
-        stats: ['cardinality'],
-      })
+      buildQuery(
+        {
+          key: 'test',
+          type: 'fieldValuePartitionGroupStats',
+          groupField: 'Vendor.City',
+          statsField: 'LineItem.TotalPrice',
+          matchValue: 'Washington',
+          stats: ['cardinality'],
+        },
+        testSchema('Vendor.City')
+      )
     ).to.eql({
       aggs: {
         groups: {

--- a/test/example-types/metricGroups/fieldValuesGroupStats.js
+++ b/test/example-types/metricGroups/fieldValuesGroupStats.js
@@ -2,6 +2,7 @@ let {
   buildQuery,
 } = require('../../../src/example-types/metricGroups/fieldValuesGroupStats')
 let { expect } = require('chai')
+let { testSchema } = require('../testUtils')
 
 describe('fieldValuesGroupStats', () => {
   it('should buildQuery', () => {
@@ -13,13 +14,7 @@ describe('fieldValuesGroupStats', () => {
           groupField: 'Organization.Name',
           statsField: 'LineItem.TotalPrice',
         },
-        {
-          fields: {
-            'Organization.Name': {
-              elasticsearch: { notAnalyzedField: 'untouched' },
-            },
-          },
-        }
+        testSchema('Organization.Name')
       )
     ).to.eql({
       aggs: {


### PR DESCRIPTION
- Example types' context is now valid even if `statsField` is not passed.
- Use `getField` in `fieldValuePartitionGroupStats` to map field to its un-analyzed value.