### PR TITLE
fix: properly pass the headers to client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#1.2.1
+* Pass the headers in the manner expected by the elastic client
+
 #1.2.0
 * Add last1Day and last1Hour to dateMath util
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ let ElasticsearchProvider = (config = { request: {} }) => ({
       : (...args) => client.search(...args)
     let response
     try {
-      let { body } = await search(request, requestOptions)
+      let { body } = await search(request, { headers: requestOptions })
       response = body
     } catch (e) {
       response = e


### PR DESCRIPTION
The ES Client expects headers to be passed in the second options object within a `headers` field.