### PR TITLE
feat: create a child client on every search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#1.3.0
+* Create a new child client on every search to allow passing headers and other options on a per search basis
+
 #1.2.0
 * Add last1Day and last1Hour to dateMath util
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -46,8 +46,7 @@ let ElasticsearchProvider = (config = { request: {} }) => {
             },
           }
 
-      let client = config.getClient()
-      let child = client.child({
+      let child = config.getClient().child({
         headers: requestOptions.headers,
         requestTimeout: requestOptions.requestTimeout,
       })

--- a/src/index.js
+++ b/src/index.js
@@ -48,11 +48,15 @@ let ElasticsearchProvider = (config = { request: {} }) => ({
         })
 
     let client = config.getClient()
+    let child = client.child({
+      headers: requestOptions.headers,
+      requestTimeout: requestOptions.requestTimeout
+    })
     // If we have a scrollId, use a different client API method
     // The new elasticsearch client uses `this`, so we can just pass aroud `client.search` :(
     let search = scrollId
-      ? (...args) => client.scroll(...args)
-      : (...args) => client.search(...args)
+      ? (...args) => child.scroll(...args)
+      : (...args) => child.search(...args)
     let response
     try {
       let { body } = await search(request, requestOptions)

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ let ElasticsearchProvider = (config = { request: {} }) => {
         },
       }
     },
-    async runSearch({ requestOptions } = {}, node, schema, filters, aggs) {
+    async runSearch({ requestOptions = {} } = {}, node, schema, filters, aggs) {
       let { scroll, scrollId } = node
       let request = scrollId
         ? // If we have scrollId then keep scrolling, no query needed

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ let ElasticsearchProvider = (config = { request: {} }) => ({
       },
     }
   },
-  async runSearch({ requestOptions } = {}, node, schema, filters, aggs) {
+  async runSearch({ requestOptions = {} } = {}, node, schema, filters, aggs) {
     let { scroll, scrollId } = node
     let request = scrollId
       ? // If we have scrollId then keep scrolling, no query needed

--- a/test/index.js
+++ b/test/index.js
@@ -15,6 +15,8 @@ const query_string = {
   default_operator: 'AND',
   query: 'something',
 }
+const initialNode = { config: {}, _meta: { requests: [] } }
+const initialSchema = { elasticsearch: {} }
 
 describe.only('Core Provider', () => {
   it('groupCombinator should return a query joining filters by group.join', () => {
@@ -32,19 +34,16 @@ describe.only('Core Provider', () => {
       },
     })
   })
-  it('runSearch should wrap queries in constant_score if sort._score is not present', async () => {
+  it('runSearch should wrap queries in constant_score if sort._score is not present', () => {
     const client = {
       child: sinon
         .stub()
         .returns({ search: sinon.stub().returns(Promise.resolve({})) }),
     }
 
-    const node = { config: {}, _meta: { requests: [] } }
-    const schema = { elasticsearch: {} }
-
     provider({
       getClient: () => client,
-    }).runSearch({}, node, schema, { query_string }, {})
+    }).runSearch({}, initialNode, initialSchema, { query_string }, {})
 
     let firstSearchCall = client.child.firstCall.returnValue.search.firstCall
 
@@ -59,12 +58,9 @@ describe.only('Core Provider', () => {
         .returns({ search: sinon.stub().returns(Promise.resolve({})) }),
     }
 
-    const node = { config: {}, _meta: { requests: [] } }
-    const schema = { elasticsearch: {} }
-
     provider({
       getClient: () => client,
-    }).runSearch({}, node, schema, null, {})
+    }).runSearch({}, initialNode, initialSchema, null, {})
 
     let firstSearchCall = client.child.firstCall.returnValue.search.firstCall
 
@@ -77,15 +73,12 @@ describe.only('Core Provider', () => {
         .returns({ search: sinon.stub().returns(Promise.resolve({})) }),
     }
 
-    const node = { config: {}, _meta: { requests: [] } }
-    const schema = { elasticsearch: {} }
-
     provider({
       getClient: () => client,
     }).runSearch(
       {},
-      node,
-      schema,
+      initialNode,
+      initialSchema,
       { query_string },
       { sort: { _score: 'desc' } }
     )
@@ -96,24 +89,26 @@ describe.only('Core Provider', () => {
       query_string,
     })
   })
-  it('should pass any request options to the child client upon initialization', async () => {
+  it('should pass any request options to the child client upon initialization', () => {
     const client = {
       child: sinon
         .stub()
         .returns({ search: sinon.stub().returns(Promise.resolve({})) }),
     }
 
-    const node = { config: {}, _meta: { requests: [] } }
-    const schema = { elasticsearch: {} }
-
     provider({
       getClient: () => client,
-    }).runSearch({ requestOptions }, node, schema, { query_string }, {})
+    }).runSearch(
+      { requestOptions },
+      initialNode,
+      initialSchema,
+      { query_string },
+      {}
+    )
 
-    let firstSearchCall = client.child.firstCall
-    console.log({ firstSearchCall })
+    let childClientStub = client.child.firstCall
 
-    expect(firstSearchCall.args[0]).to.eql({
+    expect(childClientStub.args[0]).to.eql({
       headers: requestOptions.headers,
       requestTimeout: requestOptions.requestTimeout,
     })

--- a/test/index.js
+++ b/test/index.js
@@ -18,7 +18,7 @@ const query_string = {
 const initialNode = { config: {}, _meta: { requests: [] } }
 const initialSchema = { elasticsearch: {} }
 
-describe.only('Core Provider', () => {
+describe('Core Provider', () => {
   it('groupCombinator should return a query joining filters by group.join', () => {
     expect(
       provider().groupCombinator({ join: 'or' }, ['Anything works'])


### PR DESCRIPTION
This will allow us to pass headers and things like requestTimeout on a per search basis.