### PR TITLE
Move to `date_optional_time`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#1.4.3
+* Switch from the deprecated `dateOptionalTime` to the `date_optional_time`
+
 #1.4.2
 * Fix issue with regex util to comply with https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-regexp-query.html#regexp-query-ex-request
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/filters/date.js
+++ b/src/example-types/filters/date.js
@@ -26,7 +26,7 @@ module.exports = {
         [field]: F.compactObject({
           gte: from,
           lte: to,
-          format: 'dateOptionalTime',
+          format: 'date_optional_time',
         }),
       },
     }

--- a/src/example-types/filters/dateRangeFacet.js
+++ b/src/example-types/filters/dateRangeFacet.js
@@ -33,7 +33,7 @@ module.exports = {
       _.map(({ range }) => ({
         range: {
           [field]: {
-            format: 'dateOptionalTime',
+            format: 'date_optional_time',
             ...getDateRange(range, timezone),
           },
         },
@@ -58,7 +58,7 @@ module.exports = {
         range: {
           date_range: {
             field,
-            format: format || 'dateOptionalTime',
+            format: format || 'date_optional_time',
             ranges: _.map(
               ({ range, key }) => ({
                 key,

--- a/test/example-types/filters/date.js
+++ b/test/example-types/filters/date.js
@@ -14,7 +14,7 @@ describe('date/filter', () => {
       range: {
         test: {
           gte: '2016-04-25T00:00:00.000Z',
-          format: 'dateOptionalTime',
+          format: 'date_optional_time',
         },
       },
     })
@@ -31,7 +31,7 @@ describe('date/filter', () => {
       range: {
         test: {
           lte: '2016-04-25T00:00:00.000Z',
-          format: 'dateOptionalTime',
+          format: 'date_optional_time',
         },
       },
     })
@@ -50,7 +50,7 @@ describe('date/filter', () => {
         test: {
           lte: '2016-04-25T00:00:00.000Z',
           gte: '2015-04-25T00:00:00.000Z',
-          format: 'dateOptionalTime',
+          format: 'date_optional_time',
         },
       },
     })
@@ -70,7 +70,7 @@ describe('date/filter', () => {
         test: {
           gte: 'a very specific date',
           lte: 'another very specific date',
-          format: 'dateOptionalTime',
+          format: 'date_optional_time',
         },
       },
     })

--- a/test/example-types/filters/dateRangeFacet.js
+++ b/test/example-types/filters/dateRangeFacet.js
@@ -57,7 +57,7 @@ describe('dateRangeFacet/filter', () => {
           {
             range: {
               test: {
-                format: 'dateOptionalTime',
+                format: 'date_optional_time',
                 from: getDatePart('allFutureDates', 'from'),
               },
             },

--- a/test/example-types/metricGroups/fieldValuesDelta.js
+++ b/test/example-types/metricGroups/fieldValuesDelta.js
@@ -16,14 +16,14 @@ describe('fieldValuesDelta', () => {
       field: 'PO.IssuedDate',
       gte: 'now-2y-180d',
       lte: 'now-180d',
-      format: 'dateOptionalTime',
+      format: 'date_optional_time',
     },
     foreground: {
       type: 'range',
       field: 'PO.IssuedDate',
       gte: 'now-180d',
       lte: 'now',
-      format: 'dateOptionalTime',
+      format: 'date_optional_time',
     },
   }
   it('should buildQuery', () => {
@@ -37,7 +37,7 @@ describe('fieldValuesDelta', () => {
                   'PO.IssuedDate': {
                     gte: 'now-2y-180d',
                     lte: 'now-180d',
-                    format: 'dateOptionalTime',
+                    format: 'date_optional_time',
                   },
                 },
               },
@@ -46,7 +46,7 @@ describe('fieldValuesDelta', () => {
                   'PO.IssuedDate': {
                     gte: 'now-180d',
                     lte: 'now',
-                    format: 'dateOptionalTime',
+                    format: 'date_optional_time',
                   },
                 },
               },


### PR DESCRIPTION
- Moves away from the deprecated `dateOptionalTime` and replaces it with the recommended `date_optional_time`