### PR TITLE
Fix: Pivot drilldown nested cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.8.2
+* Fix bug with pivot processReponse including groups that weren't in the query when setting a drilldown
+
 # 1.8.1
 * Fix bug with pivot drilldown wrapping tree and processResponse not handling it
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/metricGroups/pivot.js
+++ b/src/example-types/metricGroups/pivot.js
@@ -113,7 +113,14 @@ let defaultGetGroups = _.get('groups.buckets')
 let ensureGroups = node => {
   if (!_.isArray(node.groups)) node.groups = []
 }
-let processResponse = (response, { groups = [], flatten } = {}) => {
+let processResponse = (response, node = {}) => {
+  // Don't consider deeper levels than +1 the current drilldown
+  // This allows avoiding expansion until ready
+  // Opt out with falsey drilldown
+  let groups = node.drilldown
+    ? _.take(_.size(node.drilldown) + 1, node.groups || [])
+    : (node.groups || [])
+
   // Traversing the ES response utilizes type specific methods looked up by matching the depth with node.groups
   let traverseSource = (x, i, parents = []) => {
     let depth = parents.length
@@ -130,7 +137,7 @@ let processResponse = (response, { groups = [], flatten } = {}) => {
     simplifyBucket,
     F.getOrReturn('pivotFilter', response.aggregations)
   )
-  return { results: flatten ? flattenGroups(results) : results.groups }
+  return { results: node.flatten ? flattenGroups(results) : results.groups }
 }
 
 let pivot = {

--- a/src/example-types/metricGroups/pivot.js
+++ b/src/example-types/metricGroups/pivot.js
@@ -119,7 +119,7 @@ let processResponse = (response, node = {}) => {
   // Opt out with falsey drilldown
   let groups = node.drilldown
     ? _.take(_.size(node.drilldown) + 1, node.groups || [])
-    : (node.groups || [])
+    : node.groups || []
 
   // Traversing the ES response utilizes type specific methods looked up by matching the depth with node.groups
   let traverseSource = (x, i, parents = []) => {


### PR DESCRIPTION
Fix bug with pivot processReponse including groups that weren't in the query when setting a drilldown