### PR TITLE
Schema alias improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.9.0
+* Add `aliasOf` to elastic schemas (for better alias handling)
+
 # 1.8.2
 * Fix bug with pivot processReponse including groups that weren't in the query when setting a drilldown
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/schema.js
+++ b/src/schema.js
@@ -51,7 +51,7 @@ let copySchemasToAliases = schemas =>
     // only select field values which are arrays
     _.pickBy(_.isArray),
     // Just takes the first index that matched the alias
-    _.mapValues(([x]) => _.merge({ elasticsearch: { aliasOf: x} }, schemas[x]))
+    _.mapValues(([x]) => _.merge({ elasticsearch: { aliasOf: x } }, schemas[x]))
   )
 
 let fromMappingsWithAliases = (mappings, aliases) => {

--- a/src/schema.js
+++ b/src/schema.js
@@ -51,7 +51,7 @@ let copySchemasToAliases = schemas =>
     // only select field values which are arrays
     _.pickBy(_.isArray),
     // Just takes the first index that matched the alias
-    _.mapValues(([x]) => schemas[x])
+    _.mapValues(([x]) => _.merge({ elasticsearch: { aliasOf: x} }, schemas[x]))
   )
 
 let fromMappingsWithAliases = (mappings, aliases) => {

--- a/test/schema-data/schema-with-types.js
+++ b/test/schema-data/schema-with-types.js
@@ -204,6 +204,7 @@ module.exports = {
     elasticsearch: {
       index: 'imdb',
       type: 'movie',
+      aliasOf: 'movies',
     },
     fields: {
       actors: {

--- a/test/schema-data/schema-without-types.js
+++ b/test/schema-data/schema-without-types.js
@@ -30,6 +30,7 @@ module.exports = {
   imdb: {
     elasticsearch: {
       index: 'imdb',
+      aliasOf: 'movies',
     },
     fields: {
       actors: {


### PR DESCRIPTION
* Add `aliasOf` to elastic schemas (for better alias handling)

Today, aliases just show up as regular schemas. That's helpful, but it's sometimes helpful to know if you're dealing with an alias or not (for example, to filter to just one alias for a given index based on some arbitrary rules in a schema picker).