### PR TITLE
Fix: pivot total column count sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.12.2
+* [pivot] Fix sorting for a total column document count
+
 # 1.12.1
 * [pivot] Fix sorting bugs on `_count` a metrics with dots when there are no columns
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/metricGroups/pivot.js
+++ b/src/example-types/metricGroups/pivot.js
@@ -87,7 +87,7 @@ let getSortField = ({ columnValues = [], valueProp, valueIndex } = {}) =>
       ? `sortFilter${_.isNil(valueIndex) ? '.doc_count' : '>metric'}`
       : // If there are no columns, get the generated key for the value or default to _count
       _.isNil(valueIndex)
-      ? 'doc_count'
+      ? '_count'
       : 'metric',
     valueProp,
   ])
@@ -116,7 +116,7 @@ let buildQuery = async (node, schema, getStats) => {
         // At each level, add a filters bucket agg and nested metric to enable sorting
         // For example, to sort by Sum of Price for 2022, add a filters agg for 2022 and neseted metric for sum of price so we can target it
         // As far as we're aware, there's no way to sort by the nth bucket - but we can simulate that by using filters to create a discrete agg for that bucket
-        if (sortAgg) {
+        if (!_.isEmpty(sort)) {
           children = _.merge(sortAgg, await children)
           // Set `sort` on the group, deferring to each grouping type to handle it
           // The API of `{sort: {field, direction}}` is respected by fieldValues and can be added to others
@@ -146,6 +146,8 @@ let buildQuery = async (node, schema, getStats) => {
 
   // Without this, ES7+ stops counting at 10k instead of returning the actual count
   query.track_total_hits = true
+
+  console.log('query', JSON.stringify(query, null, 2))
 
   return query
 }

--- a/src/example-types/metricGroups/pivot.js
+++ b/src/example-types/metricGroups/pivot.js
@@ -147,8 +147,6 @@ let buildQuery = async (node, schema, getStats) => {
   // Without this, ES7+ stops counting at 10k instead of returning the actual count
   query.track_total_hits = true
 
-  console.log('query', JSON.stringify(query, null, 2))
-
   return query
 }
 


### PR DESCRIPTION
* [x] Pivor sort: document count using `_count` when there is no metric to sort by