### PR TITLE
Pivot node: deprecating subtotals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.12.3
+* [pivot] Fix query builder by disabling subtotals when drilling down
+
 # 1.12.2
 * [pivot] Fix sorting for a total column document count
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-# 1.12.3
-* [pivot] Fix query builder by disabling subtotals when drilling down
+# 1.13.0
+* [pivot] Removing support for subtotals flag and making it automatic if there is no flatten or drilldown
 
 # 1.12.2
 * [pivot] Fix sorting for a total column document count

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "1.12.3",
+  "version": "1.13.0",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/metricGroups/pivot.js
+++ b/src/example-types/metricGroups/pivot.js
@@ -110,9 +110,9 @@ let buildQuery = async (node, schema, getStats) => {
 
     return _.reduce(
       async (children, group) => {
-        // Subtotals calculates metrics at each group level, not needed if flattening, drilling down or in chart
+        // Calculating subtotal metrics at each group level if not flattening or drilling down
         // Support for per group stats could also be added here - merge on another stats agg blob to children based on group.stats/statsField or group.values
-        if (node.subtotals && !node.drilldown)
+        if (!node.flatten && !node.drilldown)
           children = _.merge(await children, statsAggs)
         // At each level, add a filters bucket agg and nested metric to enable sorting
         // For example, to sort by Sum of Price for 2022, add a filters agg for 2022 and neseted metric for sum of price so we can target it
@@ -165,7 +165,7 @@ let flattenGroups = Tree.leavesBy((node, index, parents) => ({
   ..._.mergeAll(
     F.mapIndexed(
       bucketToGroupN,
-      // dropping root parent (since that is just the aggs top level - would change if we add "totals" to the subtotals)
+      // dropping root parent (since it's just the aggs top level - would change if we add "totals" to flatten result)
       // might also change based on what we pass in (e.g. pass in aggregations.groups?)
       _.reverse([node, ..._.dropRight(1, parents)])
     )

--- a/src/example-types/metricGroups/pivot.js
+++ b/src/example-types/metricGroups/pivot.js
@@ -110,9 +110,10 @@ let buildQuery = async (node, schema, getStats) => {
 
     return _.reduce(
       async (children, group) => {
-        // Subtotals calculates metrics at each group level, not needed if flattening or in chart
+        // Subtotals calculates metrics at each group level, not needed if flattening, drilling down or in chart
         // Support for per group stats could also be added here - merge on another stats agg blob to children based on group.stats/statsField or group.values
-        if (node.subtotals) children = _.merge(await children, statsAggs)
+        if (node.subtotals && !node.drilldown)
+          children = _.merge(await children, statsAggs)
         // At each level, add a filters bucket agg and nested metric to enable sorting
         // For example, to sort by Sum of Price for 2022, add a filters agg for 2022 and neseted metric for sum of price so we can target it
         // As far as we're aware, there's no way to sort by the nth bucket - but we can simulate that by using filters to create a discrete agg for that bucket


### PR DESCRIPTION
* [x] `Pivot node`: removing support for `subtotals` flag and making it automatic if there is no `flatten` or `drilldown`
* [x] Updating the tests reflect the changes
 