### PR TITLE
Fixed CI

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -13,7 +13,7 @@ jobs:
     - name: Use Node.js 16.x
       uses: actions/setup-node@v1
       with:
-        node-version: 16.x
+        node-version: 16.15.0
     - name: Cache Node.js modules
       uses: actions/cache@v2
       with:

--- a/.github/workflows/push-master.yaml
+++ b/.github/workflows/push-master.yaml
@@ -12,7 +12,7 @@ jobs:
     - name: Use Node.js 16.x
       uses: actions/setup-node@v1
       with:
-        node-version: 16.x
+        node-version: 16.15.0
     - run: npm ci
     - run: npm run build --if-present
     - run: npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.14.2
+* Fix CI. Diti has a peer dependency conflict in npm 8.11 wich ships with the latest
+  version of node so lock to node 16.15.0 for now.
+
 # 1.14.1
 * [pivot] Fix multi-term aggregation query logic
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "contexture-elasticsearch",
-      "version": "1.12.1",
+      "version": "1.14.2",
       "license": "MIT",
       "dependencies": {
         "@elastic/datemath": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
Lock to node 16.15.0 to avoid npm issues with npm 8.11 which ships
with the latest version of node.