### PR TITLE
Refactor pivot node: renaming groups to rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.15.0
+* [pivot] Renaming groups to rows
+
 # 1.14.2
 * Fix CI. Diti has a peer dependency conflict in npm 8.11 wich ships with the latest
   version of node so lock to node 16.15.0 for now.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 1.15.0
-* [pivot] Renaming groups to rows
+* [pivot] Renaming groups to rows and deprecating the flatten flag
 
 # 1.14.2
 * Fix CI. Diti has a peer dependency conflict in npm 8.11 wich ships with the latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "1.14.2",
+  "version": "1.15.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "1.14.2",
+  "version": "1.15.0",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/metricGroups/pivot.js
+++ b/src/example-types/metricGroups/pivot.js
@@ -112,8 +112,7 @@ let buildQuery = async (node, schema, getStats) => {
       async (children, row) => {
         // Calculating subtotal metrics at each row level if not drilling down
         // Support for per row stats could also be added here - merge on another stats agg blob to children based on row.stats/statsField or row.values
-        if (!node.drilldown)
-          children = _.merge(await children, statsAggs)
+        if (!node.drilldown) children = _.merge(await children, statsAggs)
         // At each level, add a filters bucket agg and nested metric to enable sorting
         // For example, to sort by Sum of Price for 2022, add a filters agg for 2022 and neseted metric for sum of price so we can target it
         // As far as we're aware, there's no way to sort by the nth bucket - but we can simulate that by using filters to create a discrete agg for that bucket

--- a/src/example-types/metricGroups/pivot.js
+++ b/src/example-types/metricGroups/pivot.js
@@ -44,19 +44,19 @@ let maybeWrapWithFilterAgg = ({ query, filters, aggName }) =>
       }
 
 // Builds filters for drilldowns
-let drilldownFilters = ({ drilldowns = [], groups = [], schema, getStats }) =>
-  compactMapAsync((group, i) => {
-    let filter = lookupTypeProp(_.stubFalse, 'drilldown', group.type)
-    // Drilldown can come from root or be inlined on the group definition
-    let drilldown = drilldowns[i] || group.drilldown
-    return drilldown && filter({ drilldown, ...group }, schema, getStats)
-  }, groups)
+let drilldownFilters = ({ drilldowns = [], rows = [], schema, getStats }) =>
+  compactMapAsync((row, i) => {
+    let filter = lookupTypeProp(_.stubFalse, 'drilldown', row.type)
+    // Drilldown can come from root or be inlined on the row definition
+    let drilldown = drilldowns[i] || row.drilldown
+    return drilldown && filter({ drilldown, ...row }, schema, getStats)
+  }, rows)
 
 let getSortAgg = async ({ node, sort, schema, getStats }) => {
   if (!sort) return
   let filters = await drilldownFilters({
     drilldowns: sort.columnValues,
-    groups: node.columns,
+    rows: node.columns,
     schema,
     getStats,
   })
@@ -97,21 +97,21 @@ let buildQuery = async (node, schema, getStats) => {
   // Don't consider deeper levels than +1 the current drilldown
   // This allows avoiding expansion until ready
   // Opt out with falsey drilldown
-  let groups = node.drilldown
-    ? _.take(_.size(node.drilldown) + 1, node.groups)
-    : node.groups
+  let rows = node.drilldown
+    ? _.take(_.size(node.drilldown) + 1, node.rows)
+    : node.rows
 
   let statsAggs = { aggs: aggsForValues(node.values, schema) }
-  // buildGroupQuery applied to a list of groups
-  let buildNestedGroupQuery = async (statsAggs, groups, groupingType, sort) => {
+  // buildGroupQuery applied to a list of rows
+  let buildNestedRowQuery = async (statsAggs, rows, groupingType, sort) => {
     // Generate filters from sort column values
     let sortAgg = await getSortAgg({ node, sort, schema, getStats })
     let sortField = getSortField(sort)
 
     return _.reduce(
-      async (children, group) => {
-        // Calculating subtotal metrics at each group level if not flattening or drilling down
-        // Support for per group stats could also be added here - merge on another stats agg blob to children based on group.stats/statsField or group.values
+      async (children, row) => {
+        // Calculating subtotal metrics at each row level if not flattening or drilling down
+        // Support for per row stats could also be added here - merge on another stats agg blob to children based on row.stats/statsField or row.values
         if (!node.flatten && !node.drilldown)
           children = _.merge(await children, statsAggs)
         // At each level, add a filters bucket agg and nested metric to enable sorting
@@ -119,30 +119,30 @@ let buildQuery = async (node, schema, getStats) => {
         // As far as we're aware, there's no way to sort by the nth bucket - but we can simulate that by using filters to create a discrete agg for that bucket
         if (!_.isEmpty(sort)) {
           children = _.merge(sortAgg, await children)
-          // Set `sort` on the group, deferring to each grouping type to handle it
+          // Set `sort` on the row, deferring to each rowing type to handle it
           // The API of `{sort: {field, direction}}` is respected by fieldValues and can be added to others
-          group.sort = { field: sortField, direction: sort.direction }
+          row.sort = { field: sortField, direction: sort.direction }
         }
-        let build = lookupTypeProp(_.identity, 'buildGroupQuery', group.type)
-        return build(group, await children, groupingType, schema, getStats)
+        let build = lookupTypeProp(_.identity, 'buildGroupQuery', row.type)
+        return build(row, await children, groupingType, schema, getStats)
       },
       statsAggs,
-      _.reverse(groups)
+      _.reverse(rows)
     )
   }
 
   if (node.columns)
     statsAggs = _.merge(
-      await buildNestedGroupQuery(statsAggs, node.columns, 'columns'),
+      await buildNestedRowQuery(statsAggs, node.columns, 'columns'),
       statsAggs
     )
   let query = _.merge(
-    await buildNestedGroupQuery(statsAggs, groups, 'groups', node.sort),
+    await buildNestedRowQuery(statsAggs, rows, 'rows', node.sort),
     // Stamping total row metrics if not drilling data
     _.isEmpty(drilldowns) ? statsAggs : {}
   )
 
-  let filters = await drilldownFilters({ drilldowns, groups, schema, getStats })
+  let filters = await drilldownFilters({ drilldowns, rows, schema, getStats })
   query = maybeWrapWithFilterAgg({ filters, aggName: 'pivotFilter', query })
 
   // Without this, ES7+ stops counting at 10k instead of returning the actual count
@@ -151,22 +151,22 @@ let buildQuery = async (node, schema, getStats) => {
   return query
 }
 
-// TODO: instead of groupN, maybe look at query to say something more valuable?
-//  e.g. => node.groups[n].field + ' ' + node.groups[n].type (aka 'Organization.NameState fieldValues'), maybe customized per type?
+// TODO: instead of rowN, maybe look at query to say something more valuable?
+//  e.g. => node.rows[n].field + ' ' + node.rows[n].type (aka 'Organization.NameState fieldValues'), maybe customized per type?
 //      eg. `PO.IssuedDate month dateInterval`
 // maybe client side since it's schema label driven?
-let bucketToGroupN = (bucket, n) => ({
-  [`group${n}`]: bucket.keyAsString || bucket.key,
+let bucketToRowN = (bucket, n) => ({
+  [`row${n}`]: bucket.keyAsString || bucket.key,
 })
-let Tree = F.tree(_.get('groups'))
-let flattenGroups = Tree.leavesBy((node, index, parents) => ({
+let Tree = F.tree(_.get('rows'))
+let flattenRows = Tree.leavesBy((node, index, parents) => ({
   ...node,
-  // Add groupN keys
+  // Add rowN keys
   ..._.mergeAll(
     F.mapIndexed(
-      bucketToGroupN,
+      bucketToRowN,
       // dropping root parent (since it's just the aggs top level - would change if we add "totals" to flatten result)
-      // might also change based on what we pass in (e.g. pass in aggregations.groups?)
+      // might also change based on what we pass in (e.g. pass in aggregations.rows?)
       _.reverse([node, ..._.dropRight(1, parents)])
     )
   ),
@@ -190,16 +190,16 @@ let processResponse = (response, node = {}) => {
 
   clearDrilldownCounts(results, _.get(['drilldown', 'length'], node))
 
-  return { results: node.flatten ? flattenGroups(results) : results }
+  return { results: node.flatten ? flattenRows(results) : results }
 }
 
 // Example Payload:
 // node.filters = [
-//   { groups: ['Reno', '0-500'], columns: ['2017'] },
-//   { groups: ['Hillsboro Beach', '2500-*'] }
+//   { rows: ['Reno', '0-500'], columns: ['2017'] },
+//   { rows: ['Hillsboro Beach', '2500-*'] }
 // ] -> (Reno AND 0-500 AND 2017) OR (Hillsboro AND 2500-*)
 let hasValue = ({ filters }) => !_.isEmpty(filters)
-let filter = async ({ filters, groups = [], columns = [] }, schema) => {
+let filter = async ({ filters, rows = [], columns = [] }, schema) => {
   // This requires getting `search` passed in to filter
   // This is a change to contexture core, which is likely a breaking change moving all contexture type methods to named object params
   //    That will allow everything to get all props inclding `search`
@@ -214,14 +214,14 @@ let filter = async ({ filters, groups = [], columns = [] }, schema) => {
           bool: {
             must: [
               ...(await drilldownFilters({
-                drilldowns: filter.groups,
-                groups,
+                drilldowns: filter.rows,
+                rows,
                 schema,
                 getStats,
               })),
               ...(await drilldownFilters({
                 drilldowns: filter.columns,
-                groups: columns,
+                rows: columns,
                 schema,
                 getStats,
               })),
@@ -240,8 +240,8 @@ let pivot = {
   aggsForValues,
   buildQuery,
   processResponse,
-  validContext: node => node.groups.length && node.values.length,
-  // TODO: unify this with groupStatsUtil - the general pipeline is the same conceptually
+  validContext: node => node.rows.length && node.values.length,
+  // TODO: unify this with rowStatsUtil - the general pipeline is the same conceptually
   async result(node, search, schema) {
     let query = await buildQuery(node, schema, getStats(search))
     // console.log(JSON.stringify({ query }, 0, 2))

--- a/src/example-types/metricGroups/pivot.js
+++ b/src/example-types/metricGroups/pivot.js
@@ -141,7 +141,12 @@ let buildQuery = async (node, schema, getStats) => {
     _.isEmpty(drilldowns) ? statsAggs : {}
   )
 
-  let filters = await drilldownFilters({ drilldowns, groups: rows, schema, getStats })
+  let filters = await drilldownFilters({
+    drilldowns,
+    groups: rows,
+    schema,
+    getStats,
+  })
   query = maybeWrapWithFilterAgg({ filters, aggName: 'pivotFilter', query })
 
   // Without this, ES7+ stops counting at 10k instead of returning the actual count

--- a/test/example-types/metricGroups/pivot.js
+++ b/test/example-types/metricGroups/pivot.js
@@ -46,7 +46,7 @@ describe('pivot', () => {
   })
   it('should buildQuery', async () => {
     // ES -> PVT
-    // buckets -> rows (rows/columns)
+    // buckets -> groups (rows/columns)
     // metrics -> values
     let input = {
       key: 'test',
@@ -2034,128 +2034,6 @@ describe('pivot', () => {
       buck.rows.buckets = buck.rows.buckets.slice(0, 2)
       return buck
     }, aggs.rows.buckets)
-
-    let flatResult = processResponse(pivotResponse, {
-      rows: [
-        { type: 'fieldValues', field: 'Organization.State' },
-        { type: 'fieldValues', field: 'Organization.NameState' },
-        {
-          type: 'numberRanges',
-          field: 'LineItem.TotalPrice',
-          ranges: [
-            { from: '0', to: '500' },
-            { from: '500', to: '10000' },
-          ],
-        },
-      ],
-      flatten: true,
-    })
-    expect(flatResult.results).to.eql([
-      {
-        key: '0.0-500.0',
-        from: 0,
-        to: 500,
-        count: 1774855,
-        avg: 123.61877539749409,
-        min: 0,
-        max: 499.989990234375,
-        sum: 219405401.60811937,
-        row0: 'Texas',
-        row1: 'UT Southwestern Medical Center, Texas',
-        row2: '0.0-500.0',
-      },
-      {
-        key: '500.0-10000.0',
-        from: 500,
-        to: 10000,
-        count: 463268,
-        avg: 1930.249843325976,
-        min: 500,
-        max: 9999.98046875,
-        sum: 894222984.4179382,
-        row0: 'Texas',
-        row1: 'UT Southwestern Medical Center, Texas',
-        row2: '500.0-10000.0',
-      },
-      {
-        key: '0.0-500.0',
-        from: 0,
-        to: 500,
-        count: 1072035,
-        avg: 86.85762873285029,
-        min: 0,
-        max: 499.989990234375,
-        sum: 93114418.01862116,
-        row0: 'Texas',
-        row1: 'University of Texas MD Anderson Cancer Center, Texas',
-        row2: '0.0-500.0',
-      },
-      {
-        key: '500.0-10000.0',
-        from: 500,
-        to: 10000,
-        count: 183007,
-        avg: 1989.2294442580583,
-        min: 500,
-        max: 9998.7998046875,
-        sum: 364042912.9053345,
-        row0: 'Texas',
-        row1: 'University of Texas MD Anderson Cancer Center, Texas',
-        row2: '500.0-10000.0',
-      },
-      {
-        key: '0.0-500.0',
-        from: 0,
-        to: 500,
-        count: 4024309,
-        avg: 96.12894216963802,
-        min: 0,
-        max: 499.989990234375,
-        sum: 386852567.13375384,
-        row0: 'Ohio',
-        row1: 'Ohio State University, Ohio',
-        row2: '0.0-500.0',
-      },
-      {
-        key: '500.0-10000.0',
-        from: 500,
-        to: 10000,
-        count: 644351,
-        avg: 1802.1472297222226,
-        min: 500,
-        max: 9999.990234375,
-        sum: 1161215369.618744,
-        row0: 'Ohio',
-        row1: 'Ohio State University, Ohio',
-        row2: '500.0-10000.0',
-      },
-      {
-        key: '0.0-500.0',
-        from: 0,
-        to: 500,
-        count: 864306,
-        avg: 101.28828428425045,
-        min: 0,
-        max: 499.989990234375,
-        sum: 87544071.83658338,
-        row0: 'Ohio',
-        row1: 'Greene County Court of Commons Pleas, Ohio',
-        row2: '0.0-500.0',
-      },
-      {
-        key: '500.0-10000.0',
-        from: 500,
-        to: 10000,
-        count: 179714,
-        avg: 1426.013434972438,
-        min: 500,
-        max: 9998,
-        sum: 256274578.45263672,
-        row0: 'Ohio',
-        row1: 'Greene County Court of Commons Pleas, Ohio',
-        row2: '500.0-10000.0',
-      },
-    ])
 
     let nestedResult = processResponse(pivotResponse)
     expect(nestedResult.results).to.eql({

--- a/test/example-types/metricGroups/pivot.js
+++ b/test/example-types/metricGroups/pivot.js
@@ -46,7 +46,7 @@ describe('pivot', () => {
   })
   it('should buildQuery', async () => {
     // ES -> PVT
-    // buckets -> groups (rows/columns)
+    // buckets -> rows (rows/columns)
     // metrics -> values
     let input = {
       key: 'test',
@@ -67,17 +67,17 @@ describe('pivot', () => {
         { type: 'cardinality', field: 'Vendor.Name' },
         { type: 'topHits' },
       ],
-      groups: [
+      rows: [
         { type: 'fieldValues', field: 'Organization.NameState' },
         { type: 'dateInterval', field: 'PO.IssuedDate', interval: 'month' },
       ],
     }
     let expected = {
       aggs: {
-        groups: {
+        rows: {
           terms: { field: 'Organization.NameState.untouched', size: 10 },
           aggs: {
-            groups: {
+            rows: {
               date_histogram: {
                 field: 'PO.IssuedDate',
                 interval: 'month',
@@ -169,7 +169,7 @@ describe('pivot', () => {
       key: 'test',
       type: 'pivot',
       values: [{ type: 'sum', field: 'LineItem.TotalPrice' }],
-      groups: [
+      rows: [
         {
           type: 'fieldValuePartition',
           field: 'Vendor.City',
@@ -180,7 +180,7 @@ describe('pivot', () => {
     let expected = {
       track_total_hits: true,
       aggs: {
-        groups: {
+        rows: {
           filters: {
             other_bucket_key: 'fail',
             filters: {
@@ -210,7 +210,7 @@ describe('pivot', () => {
       key: 'test',
       type: 'pivot',
       values: [{ type: 'sum', field: 'LineItem.TotalPrice' }],
-      groups: [
+      rows: [
         {
           type: 'fieldValues',
           field: 'Organization.Name',
@@ -237,7 +237,7 @@ describe('pivot', () => {
             },
           },
           aggs: {
-            groups: {
+            rows: {
               terms: { field: 'Organization.Name', size: 10 },
               aggs: {
                 'pivotMetric-sum-LineItem.TotalPrice': {
@@ -261,13 +261,13 @@ describe('pivot', () => {
   })
   it('should buildQuery for fieldValues with drilldown', async () => {
     // TODO: add tests for dateInterval, numberInterval, fieldValuePartition
-    // TODO: test keyForGroup (e.g. month for date interval)
+    // TODO: test keyForRow (e.g. month for date interval)
     let inputTopLevel = {
       key: 'test',
       type: 'pivot',
       values: [{ type: 'sum', field: 'LineItem.TotalPrice' }],
       drilldown: [],
-      groups: [
+      rows: [
         {
           type: 'fieldValues',
           field: 'Organization.Name',
@@ -289,7 +289,7 @@ describe('pivot', () => {
       type: 'pivot',
       values: [{ type: 'sum', field: 'LineItem.TotalPrice' }],
       drilldown: ['Reno', '0.0-500.0'],
-      groups: [
+      rows: [
         {
           type: 'fieldValues',
           field: 'Organization.Name',
@@ -311,7 +311,7 @@ describe('pivot', () => {
             bool: { must: [{ term: { 'Organization.Name': 'Reno' } }] },
           },
           aggs: {
-            groups: {
+            rows: {
               terms: { field: 'Organization.Name', size: 10 },
               aggs: {
                 'pivotMetric-sum-LineItem.TotalPrice': {
@@ -347,10 +347,10 @@ describe('pivot', () => {
             },
           },
           aggs: {
-            groups: {
+            rows: {
               terms: { field: 'Organization.Name', size: 10 },
               aggs: {
-                groups: {
+                rows: {
                   range: {
                     field: 'LineItem.TotalPrice',
                     ranges: [
@@ -389,7 +389,7 @@ describe('pivot', () => {
       type: 'pivot',
       values: [{ type: 'sum', field: 'LineItem.TotalPrice' }],
       drilldown: [],
-      groups: [
+      rows: [
         {
           type: 'fieldValues',
           field: 'Organization.Name',
@@ -407,7 +407,7 @@ describe('pivot', () => {
     let expected = {
       track_total_hits: true,
       aggs: {
-        groups: {
+        rows: {
           terms: { field: 'Organization.Name', size: 10 },
           aggs: {
             'pivotMetric-sum-LineItem.TotalPrice': {
@@ -433,7 +433,7 @@ describe('pivot', () => {
       type: 'pivot',
       values: [{ type: 'sum', field: 'LineItem.TotalPrice' }],
       drilldown: ['Reno'],
-      groups: [
+      rows: [
         {
           type: 'fieldValues',
           field: 'Organization.Name',
@@ -460,10 +460,10 @@ describe('pivot', () => {
             bool: { must: [{ term: { 'Organization.Name': 'Reno' } }] },
           },
           aggs: {
-            groups: {
+            rows: {
               terms: { field: 'Organization.Name', size: 10 },
               aggs: {
-                groups: {
+                rows: {
                   range: {
                     field: 'LineItem.TotalPrice',
                     ranges: [
@@ -496,7 +496,7 @@ describe('pivot', () => {
       type: 'pivot',
       values: [{ type: 'sum', field: 'LineItem.TotalPrice' }],
       drilldown: ['Reno', '0.0-500.0', 'A - U.S. OWNED BUSINESS'],
-      groups: [
+      rows: [
         {
           type: 'fieldValues',
           field: 'Organization.Name',
@@ -543,13 +543,13 @@ describe('pivot', () => {
             },
           },
           aggs: {
-            groups: {
+            rows: {
               terms: {
                 field: 'Organization.Name',
                 size: 10,
               },
               aggs: {
-                groups: {
+                rows: {
                   range: {
                     field: 'LineItem.TotalPrice',
                     ranges: [
@@ -564,7 +564,7 @@ describe('pivot', () => {
                     ],
                   },
                   aggs: {
-                    groups: {
+                    rows: {
                       terms: {
                         field: 'Organization.Type',
                         size: 10,
@@ -598,7 +598,7 @@ describe('pivot', () => {
       key: 'test',
       type: 'pivot',
       values: [{ type: 'sum', field: 'LineItem.TotalPrice' }],
-      groups: [
+      rows: [
         {
           type: 'numberInterval',
           field: 'LineItem.UnitPrice',
@@ -609,7 +609,7 @@ describe('pivot', () => {
     let expected = {
       track_total_hits: true,
       aggs: {
-        groups: {
+        rows: {
           histogram: {
             field: 'LineItem.UnitPrice',
             interval: 25,
@@ -636,7 +636,7 @@ describe('pivot', () => {
   })
   it('should buildQuery with subtotals', async () => {
     // ES -> PVT
-    // buckets -> groups (rows/columns)
+    // buckets -> rows (rows/columns)
     // metrics -> values
     let input = {
       key: 'test',
@@ -647,7 +647,7 @@ describe('pivot', () => {
         { type: 'avg', field: 'LineItem.TotalPrice' },
         { type: 'sum', field: 'LineItem.TotalPrice' },
       ],
-      groups: [
+      rows: [
         { type: 'fieldValues', field: 'Organization.NameState' },
         { type: 'dateInterval', field: 'PO.IssuedDate', interval: 'month' },
       ],
@@ -655,10 +655,10 @@ describe('pivot', () => {
     let expected = {
       track_total_hits: true,
       aggs: {
-        groups: {
+        rows: {
           terms: { field: 'Organization.NameState.untouched', size: 10 },
           aggs: {
-            groups: {
+            rows: {
               date_histogram: {
                 field: 'PO.IssuedDate',
                 interval: 'month',
@@ -724,7 +724,7 @@ describe('pivot', () => {
         { type: 'avg', field: 'LineItem.TotalPrice' },
         { type: 'sum', field: 'LineItem.TotalPrice' },
       ],
-      groups: [
+      rows: [
         { type: 'fieldValues', field: 'Organization.State' },
         { type: 'fieldValues', field: 'Organization.NameState' },
         {
@@ -739,13 +739,13 @@ describe('pivot', () => {
     }
     let expected = {
       aggs: {
-        groups: {
+        rows: {
           terms: { field: 'Organization.State.untouched', size: 10 },
           aggs: {
-            groups: {
+            rows: {
               terms: { field: 'Organization.NameState.untouched', size: 10 },
               aggs: {
-                groups: {
+                rows: {
                   range: {
                     field: 'LineItem.TotalPrice',
                     ranges: [
@@ -828,7 +828,7 @@ describe('pivot', () => {
         { type: 'avg', field: 'LineItem.TotalPrice' },
         { type: 'sum', field: 'LineItem.TotalPrice' },
       ],
-      groups: [
+      rows: [
         { type: 'fieldValues', field: 'Organization.State' },
         { type: 'fieldValues', field: 'Organization.NameState' },
         {
@@ -846,13 +846,13 @@ describe('pivot', () => {
     }
     let expected = {
       aggs: {
-        groups: {
+        rows: {
           terms: { field: 'Organization.State.untouched', size: 10 },
           aggs: {
-            groups: {
+            rows: {
               terms: { field: 'Organization.NameState.untouched', size: 10 },
               aggs: {
-                groups: {
+                rows: {
                   range: {
                     field: 'LineItem.TotalPrice',
                     ranges: [
@@ -1014,7 +1014,7 @@ describe('pivot', () => {
       key: 'test',
       type: 'pivot',
       values: [{ type: 'sum', field: 'LineItem.TotalPrice' }],
-      groups: [
+      rows: [
         { type: 'fieldValues', field: 'Organization.State' },
         { type: 'fieldValues', field: 'Organization.NameState' },
       ],
@@ -1025,10 +1025,10 @@ describe('pivot', () => {
     let expected = {
       track_total_hits: true,
       aggs: {
-        groups: {
+        rows: {
           terms: { field: 'Organization.State.untouched', size: 10 },
           aggs: {
-            groups: {
+            rows: {
               terms: { field: 'Organization.NameState.untouched', size: 10 },
               aggs: {
                 columns: {
@@ -1095,7 +1095,7 @@ describe('pivot', () => {
       key: 'test',
       type: 'pivot',
       values: [{ type: 'sum', field: 'PO.IssuedAmount' }],
-      groups: [
+      rows: [
         {
           type: 'fieldValues',
           field: 'Organization.State',
@@ -1114,7 +1114,7 @@ describe('pivot', () => {
     }
     let expected = {
       aggs: {
-        groups: {
+        rows: {
           terms: {
             field: 'Organization.State.untouched',
             size: 10,
@@ -1180,12 +1180,12 @@ describe('pivot', () => {
     )
     expect(result).to.eql(expected)
   })
-  it('should build query and sort on the group if top-level sort is missing', async () => {
+  it('should build query and sort on the row if top-level sort is missing', async () => {
     let input = {
       key: 'test',
       type: 'pivot',
       values: [{ type: 'sum', field: 'PO.IssuedAmount' }],
-      groups: [
+      rows: [
         {
           type: 'fieldValues',
           field: 'Organization.State',
@@ -1198,7 +1198,7 @@ describe('pivot', () => {
     }
     let expected = {
       aggs: {
-        groups: {
+        rows: {
           terms: {
             field: 'Organization.State.untouched',
             size: 10,
@@ -1257,7 +1257,7 @@ describe('pivot', () => {
         { type: 'sum', field: 'PO.IssuedAmount' },
         { type: 'avg', field: 'PO.IssuedAmount' },
       ],
-      groups: [{ type: 'fieldValues', field: 'Organization.State' }],
+      rows: [{ type: 'fieldValues', field: 'Organization.State' }],
       columns: [
         { type: 'dateInterval', field: 'PO.IssuedDate', interval: 'year' },
       ],
@@ -1269,7 +1269,7 @@ describe('pivot', () => {
     }
     let expected = {
       aggs: {
-        groups: {
+        rows: {
           terms: {
             field: 'Organization.State.untouched',
             size: 10,
@@ -1374,7 +1374,7 @@ describe('pivot', () => {
         { type: 'sum', field: 'PO.IssuedAmount' },
         { type: 'avg', field: 'PO.IssuedAmount' },
       ],
-      groups: [{ type: 'fieldValues', field: 'Organization.State' }],
+      rows: [{ type: 'fieldValues', field: 'Organization.State' }],
       columns: [
         { type: 'dateInterval', field: 'PO.IssuedDate', interval: 'year' },
       ],
@@ -1382,7 +1382,7 @@ describe('pivot', () => {
     }
     let expected = {
       aggs: {
-        groups: {
+        rows: {
           terms: {
             field: 'Organization.State.untouched',
             size: 10,
@@ -1453,7 +1453,7 @@ describe('pivot', () => {
         { type: 'sum', field: 'PO.IssuedAmount' },
         { type: 'avg', field: 'PO.IssuedAmount' },
       ],
-      groups: [{ type: 'fieldValues', field: 'Organization.State' }],
+      rows: [{ type: 'fieldValues', field: 'Organization.State' }],
       columns: [
         { type: 'dateInterval', field: 'PO.IssuedDate', interval: 'year' },
       ],
@@ -1461,7 +1461,7 @@ describe('pivot', () => {
     }
     let expected = {
       aggs: {
-        groups: {
+        rows: {
           terms: {
             field: 'Organization.State.untouched',
             size: 10,
@@ -1528,7 +1528,7 @@ describe('pivot', () => {
       key: 'test',
       type: 'pivot',
       values: [{ type: 'sum', field: 'PO.IssuedAmount' }],
-      groups: [{ type: 'fieldValues', field: 'Organization.State' }],
+      rows: [{ type: 'fieldValues', field: 'Organization.State' }],
       columns: [
         { type: 'dateInterval', field: 'PO.IssuedDate', interval: 'year' },
         { type: 'dateInterval', field: 'PO.IssuedDate', interval: 'month' },
@@ -1541,7 +1541,7 @@ describe('pivot', () => {
     }
     let expected = {
       aggs: {
-        groups: {
+        rows: {
           terms: {
             field: 'Organization.State.untouched',
             size: 10,
@@ -1639,12 +1639,12 @@ describe('pivot', () => {
     )
     expect(result).to.eql(expected)
   })
-  it('should build query with multiple groups, columns, and sort', async () => {
+  it('should build query with multiple rows, columns, and sort', async () => {
     let input = {
       key: 'test',
       type: 'pivot',
       values: [{ type: 'stats', field: 'PO.IssuedAmount' }],
-      groups: [
+      rows: [
         { type: 'fieldValues', field: 'Organization.State' },
         { type: 'fieldValues', field: 'Organization.NameState' },
       ],
@@ -1660,7 +1660,7 @@ describe('pivot', () => {
     }
     let expected = {
       aggs: {
-        groups: {
+        rows: {
           terms: {
             field: 'Organization.State.untouched',
             size: 10,
@@ -1684,7 +1684,7 @@ describe('pivot', () => {
               },
               aggs: { metric: { stats: { field: 'PO.IssuedAmount' } } },
             },
-            groups: {
+            rows: {
               terms: {
                 field: 'Organization.NameState.untouched',
                 size: 10,
@@ -1767,12 +1767,12 @@ describe('pivot', () => {
     )
     expect(result).to.eql(expected)
   })
-  it('should build query with multiple groups, columns, and sort on _count without valueIndex', async () => {
+  it('should build query with multiple rows, columns, and sort on _count without valueIndex', async () => {
     let input = {
       key: 'test',
       type: 'pivot',
       values: [{ type: 'stats', field: 'PO.IssuedAmount' }],
-      groups: [
+      rows: [
         { type: 'fieldValues', field: 'Organization.State' },
         { type: 'fieldValues', field: 'Organization.NameState' },
       ],
@@ -1786,7 +1786,7 @@ describe('pivot', () => {
     }
     let expected = {
       aggs: {
-        groups: {
+        rows: {
           terms: {
             field: 'Organization.State.untouched',
             size: 10,
@@ -1811,7 +1811,7 @@ describe('pivot', () => {
                 },
               },
             },
-            groups: {
+            rows: {
               terms: {
                 field: 'Organization.NameState.untouched',
                 size: 10,
@@ -1912,7 +1912,7 @@ describe('pivot', () => {
       key: 'test',
       type: 'pivot',
       values: [{ type: 'sum', field: 'LineItem.TotalPrice' }],
-      groups: [
+      rows: [
         { type: 'fieldValues', field: 'Organization.State' },
         { type: 'fieldValues', field: 'Organization.NameState' },
       ],
@@ -1924,10 +1924,10 @@ describe('pivot', () => {
     let expected = {
       track_total_hits: true,
       aggs: {
-        groups: {
+        rows: {
           terms: { field: 'Organization.State.untouched', size: 10 },
           aggs: {
-            groups: {
+            rows: {
               terms: { field: 'Organization.NameState.untouched', size: 10 },
               aggs: {
                 columns: {
@@ -2029,14 +2029,14 @@ describe('pivot', () => {
     let aggs = pivotResponse.aggregations
 
     // make tiny
-    aggs.groups.buckets = aggs.groups.buckets.slice(0, 2)
-    aggs.groups.buckets = _.map(buck => {
-      buck.groups.buckets = buck.groups.buckets.slice(0, 2)
+    aggs.rows.buckets = aggs.rows.buckets.slice(0, 2)
+    aggs.rows.buckets = _.map(buck => {
+      buck.rows.buckets = buck.rows.buckets.slice(0, 2)
       return buck
-    }, aggs.groups.buckets)
+    }, aggs.rows.buckets)
 
     let flatResult = processResponse(pivotResponse, {
-      groups: [
+      rows: [
         { type: 'fieldValues', field: 'Organization.State' },
         { type: 'fieldValues', field: 'Organization.NameState' },
         {
@@ -2060,9 +2060,9 @@ describe('pivot', () => {
         min: 0,
         max: 499.989990234375,
         sum: 219405401.60811937,
-        group0: 'Texas',
-        group1: 'UT Southwestern Medical Center, Texas',
-        group2: '0.0-500.0',
+        row0: 'Texas',
+        row1: 'UT Southwestern Medical Center, Texas',
+        row2: '0.0-500.0',
       },
       {
         key: '500.0-10000.0',
@@ -2073,9 +2073,9 @@ describe('pivot', () => {
         min: 500,
         max: 9999.98046875,
         sum: 894222984.4179382,
-        group0: 'Texas',
-        group1: 'UT Southwestern Medical Center, Texas',
-        group2: '500.0-10000.0',
+        row0: 'Texas',
+        row1: 'UT Southwestern Medical Center, Texas',
+        row2: '500.0-10000.0',
       },
       {
         key: '0.0-500.0',
@@ -2086,9 +2086,9 @@ describe('pivot', () => {
         min: 0,
         max: 499.989990234375,
         sum: 93114418.01862116,
-        group0: 'Texas',
-        group1: 'University of Texas MD Anderson Cancer Center, Texas',
-        group2: '0.0-500.0',
+        row0: 'Texas',
+        row1: 'University of Texas MD Anderson Cancer Center, Texas',
+        row2: '0.0-500.0',
       },
       {
         key: '500.0-10000.0',
@@ -2099,9 +2099,9 @@ describe('pivot', () => {
         min: 500,
         max: 9998.7998046875,
         sum: 364042912.9053345,
-        group0: 'Texas',
-        group1: 'University of Texas MD Anderson Cancer Center, Texas',
-        group2: '500.0-10000.0',
+        row0: 'Texas',
+        row1: 'University of Texas MD Anderson Cancer Center, Texas',
+        row2: '500.0-10000.0',
       },
       {
         key: '0.0-500.0',
@@ -2112,9 +2112,9 @@ describe('pivot', () => {
         min: 0,
         max: 499.989990234375,
         sum: 386852567.13375384,
-        group0: 'Ohio',
-        group1: 'Ohio State University, Ohio',
-        group2: '0.0-500.0',
+        row0: 'Ohio',
+        row1: 'Ohio State University, Ohio',
+        row2: '0.0-500.0',
       },
       {
         key: '500.0-10000.0',
@@ -2125,9 +2125,9 @@ describe('pivot', () => {
         min: 500,
         max: 9999.990234375,
         sum: 1161215369.618744,
-        group0: 'Ohio',
-        group1: 'Ohio State University, Ohio',
-        group2: '500.0-10000.0',
+        row0: 'Ohio',
+        row1: 'Ohio State University, Ohio',
+        row2: '500.0-10000.0',
       },
       {
         key: '0.0-500.0',
@@ -2138,9 +2138,9 @@ describe('pivot', () => {
         min: 0,
         max: 499.989990234375,
         sum: 87544071.83658338,
-        group0: 'Ohio',
-        group1: 'Greene County Court of Commons Pleas, Ohio',
-        group2: '0.0-500.0',
+        row0: 'Ohio',
+        row1: 'Greene County Court of Commons Pleas, Ohio',
+        row2: '0.0-500.0',
       },
       {
         key: '500.0-10000.0',
@@ -2151,22 +2151,22 @@ describe('pivot', () => {
         min: 500,
         max: 9998,
         sum: 256274578.45263672,
-        group0: 'Ohio',
-        group1: 'Greene County Court of Commons Pleas, Ohio',
-        group2: '500.0-10000.0',
+        row0: 'Ohio',
+        row1: 'Greene County Court of Commons Pleas, Ohio',
+        row2: '500.0-10000.0',
       },
     ])
 
     let nestedResult = processResponse(pivotResponse)
     expect(nestedResult.results).to.eql({
       count: 442825686,
-      groups: [
+      rows: [
         {
           key: 'Texas',
-          groups: [
+          rows: [
             {
               key: 'UT Southwestern Medical Center, Texas',
-              groups: [
+              rows: [
                 {
                   key: '0.0-500.0',
                   from: 0,
@@ -2192,7 +2192,7 @@ describe('pivot', () => {
             },
             {
               key: 'University of Texas MD Anderson Cancer Center, Texas',
-              groups: [
+              rows: [
                 {
                   key: '0.0-500.0',
                   from: 0,
@@ -2221,10 +2221,10 @@ describe('pivot', () => {
         },
         {
           key: 'Ohio',
-          groups: [
+          rows: [
             {
               key: 'Ohio State University, Ohio',
-              groups: [
+              rows: [
                 {
                   key: '0.0-500.0',
                   from: 0,
@@ -2250,7 +2250,7 @@ describe('pivot', () => {
             },
             {
               key: 'Greene County Court of Commons Pleas, Ohio',
-              groups: [
+              rows: [
                 {
                   key: '0.0-500.0',
                   from: 0,
@@ -2280,12 +2280,12 @@ describe('pivot', () => {
       ],
     })
   })
-  it('should handle pivotResponse with filtered fieldValueGroup', () => {
+  it('should handle pivotResponse with filtered fieldValueRow', () => {
     let nestedResult = processResponse(
       pivotRepsonseWithFilteredFieldValueGroup,
       {
         values: [{ field: 'PO.IssuedAmount', type: 'avg' }],
-        groups: [
+        rows: [
           {
             field: 'Organization.NameState',
             type: 'fieldValues',
@@ -2297,11 +2297,11 @@ describe('pivot', () => {
     )
     expect(nestedResult.results).to.eql({
       count: 574247,
-      groups: [
+      rows: [
         {
           key: 'Okeechobee County Schools, Florida',
           count: 552831,
-          groups: [
+          rows: [
             {
               keyAsString: '2015-01-01T00:00:00.000Z',
               key: 1420070400000,
@@ -2349,7 +2349,7 @@ describe('pivot', () => {
         {
           key: "Okeechobee County Sheriff's Office, Florida",
           count: 11984,
-          groups: [
+          rows: [
             {
               keyAsString: '2015-01-01T00:00:00.000Z',
               key: 1420070400000,
@@ -2397,7 +2397,7 @@ describe('pivot', () => {
         {
           key: 'Okeechobee County Board of County Commissioners, Florida',
           count: 5100,
-          groups: [
+          rows: [
             {
               keyAsString: '2018-01-01T00:00:00.000Z',
               key: 1514764800000,
@@ -2427,7 +2427,7 @@ describe('pivot', () => {
         {
           key: 'Okeechobee Soil And Water Conservation District, Florida',
           count: 2983,
-          groups: [
+          rows: [
             {
               keyAsString: '2015-01-01T00:00:00.000Z',
               key: 1420070400000,
@@ -2475,7 +2475,7 @@ describe('pivot', () => {
         {
           key: 'Okeechobee County Clerk of the Circuit Court, Florida',
           count: 1349,
-          groups: [
+          rows: [
             {
               keyAsString: '2015-01-01T00:00:00.000Z',
               key: 1420070400000,
@@ -2528,7 +2528,7 @@ describe('pivot', () => {
       key: 'test',
       type: 'pivot',
       values: [{ type: 'sum', field: 'LineItem.TotalPrice' }],
-      groups: [
+      rows: [
         { type: 'fieldValues', field: 'Organization.State' },
         { type: 'fieldValues', field: 'Organization.NameState' },
       ],
@@ -2543,7 +2543,7 @@ describe('pivot', () => {
       key: 'test',
       type: 'pivot',
       values: [{ type: 'stats', field: 'PO.IssuedAmount' }],
-      groups: [
+      rows: [
         { type: 'fieldValues', field: 'Organization.State' },
         { type: 'fieldValues', field: 'Organization.City' },
       ],
@@ -2555,8 +2555,8 @@ describe('pivot', () => {
         direction: 'desc',
       },
       filters: [
-        { groups: ['Nevada', 'Reno'], columns: ['2017'] },
-        { groups: ['Florida', 'Hillsboro Beach'] },
+        { rows: ['Nevada', 'Reno'], columns: ['2017'] },
+        { rows: ['Florida', 'Hillsboro Beach'] },
       ],
     }
     let expected = {

--- a/test/example-types/metricGroups/pivotData/columnResponse.js
+++ b/test/example-types/metricGroups/pivotData/columnResponse.js
@@ -16,7 +16,7 @@ module.exports = {
     hits: [],
   },
   aggregations: {
-    groups: {
+    rows: {
       doc_count_error_upper_bound: 13746838,
       sum_other_doc_count: 498980578,
       buckets: [
@@ -91,7 +91,7 @@ module.exports = {
               },
             ],
           },
-          groups: {
+          rows: {
             doc_count_error_upper_bound: 620649,
             sum_other_doc_count: 81659479,
             buckets: [
@@ -785,7 +785,7 @@ module.exports = {
               },
             ],
           },
-          groups: {
+          rows: {
             doc_count_error_upper_bound: 283965,
             sum_other_doc_count: 47833322,
             buckets: [
@@ -1512,7 +1512,7 @@ module.exports = {
               },
             ],
           },
-          groups: {
+          rows: {
             doc_count_error_upper_bound: 330634,
             sum_other_doc_count: 62149151,
             buckets: [
@@ -2206,7 +2206,7 @@ module.exports = {
               },
             ],
           },
-          groups: {
+          rows: {
             doc_count_error_upper_bound: 142438,
             sum_other_doc_count: 13090303,
             buckets: [
@@ -2928,7 +2928,7 @@ module.exports = {
               },
             ],
           },
-          groups: {
+          rows: {
             doc_count_error_upper_bound: 284806,
             sum_other_doc_count: 27292910,
             buckets: [
@@ -3646,7 +3646,7 @@ module.exports = {
               },
             ],
           },
-          groups: {
+          rows: {
             doc_count_error_upper_bound: 201368,
             sum_other_doc_count: 32087651,
             buckets: [
@@ -4380,7 +4380,7 @@ module.exports = {
               },
             ],
           },
-          groups: {
+          rows: {
             doc_count_error_upper_bound: 132005,
             sum_other_doc_count: 34696709,
             buckets: [
@@ -5124,7 +5124,7 @@ module.exports = {
               },
             ],
           },
-          groups: {
+          rows: {
             doc_count_error_upper_bound: 94520,
             sum_other_doc_count: 15524922,
             buckets: [
@@ -5843,7 +5843,7 @@ module.exports = {
               },
             ],
           },
-          groups: {
+          rows: {
             doc_count_error_upper_bound: 154974,
             sum_other_doc_count: 23304477,
             buckets: [
@@ -6521,7 +6521,7 @@ module.exports = {
               },
             ],
           },
-          groups: {
+          rows: {
             doc_count_error_upper_bound: 154879,
             sum_other_doc_count: 28723862,
             buckets: [

--- a/test/example-types/metricGroups/pivotData/columnResult.js
+++ b/test/example-types/metricGroups/pivotData/columnResult.js
@@ -1,6 +1,6 @@
 module.exports = {
   count: 10000,
-  groups: [
+  rows: [
     {
       key: 'Texas',
       count: 93706288,
@@ -54,7 +54,7 @@ module.exports = {
           'sum-LineItem.TotalPrice': 679212887.2353557,
         },
       ],
-      groups: [
+      rows: [
         {
           key: 'UT Southwestern Medical Center, Texas',
           count: 2709459,
@@ -572,7 +572,7 @@ module.exports = {
           'sum-LineItem.TotalPrice': 16351582557.382181,
         },
       ],
-      groups: [
+      rows: [
         {
           key: 'County of Los Angeles, California',
           count: 11749880,
@@ -1115,7 +1115,7 @@ module.exports = {
           'sum-LineItem.TotalPrice': 600081554.0717431,
         },
       ],
-      groups: [
+      rows: [
         {
           key: 'Ohio State University, Ohio',
           count: 5130882,
@@ -1633,7 +1633,7 @@ module.exports = {
           'sum-LineItem.TotalPrice': 81117769.23469706,
         },
       ],
-      groups: [
+      rows: [
         {
           key: 'Department of Defense: Defense Logistics Agency, Virginia',
           count: 22465914,
@@ -2170,7 +2170,7 @@ module.exports = {
           'sum-LineItem.TotalPrice': 301807348.79818183,
         },
       ],
-      groups: [
+      rows: [
         {
           key: 'Jackson Health System, Florida',
           count: 10566550,
@@ -2706,7 +2706,7 @@ module.exports = {
           'sum-LineItem.TotalPrice': 2850050929.4705133,
         },
       ],
-      groups: [
+      rows: [
         {
           key: 'State University of New York SUNY Buffalo, New York',
           count: 1787226,
@@ -3254,7 +3254,7 @@ module.exports = {
           'sum-LineItem.TotalPrice': 409772452.5921867,
         },
       ],
-      groups: [
+      rows: [
         {
           key: 'Chicago Public Schools, Illinois',
           count: 2560815,
@@ -3809,7 +3809,7 @@ module.exports = {
           'sum-LineItem.TotalPrice': 218859204.95522404,
         },
       ],
-      groups: [
+      rows: [
         {
           key: 'University of Michigan at Ann Arbor, Michigan',
           count: 14755861,
@@ -4345,7 +4345,7 @@ module.exports = {
           'sum-LineItem.TotalPrice': 130193241.35138677,
         },
       ],
-      groups: [
+      rows: [
         {
           key: 'University of Washington, Washington',
           count: 4944799,
@@ -4851,7 +4851,7 @@ module.exports = {
           'sum-LineItem.TotalPrice': 493980697.6562287,
         },
       ],
-      groups: [
+      rows: [
         {
           key: 'Newark Public Schools, New Jersey',
           count: 384565,

--- a/test/example-types/metricGroups/pivotData/pivotRepsonseWithFilteredFieldValueGroup.js
+++ b/test/example-types/metricGroups/pivotData/pivotRepsonseWithFilteredFieldValueGroup.js
@@ -18,14 +18,14 @@ let response = {
   aggregations: {
     valueFilter: {
       doc_count: 574247,
-      groups: {
+      rows: {
         doc_count_error_upper_bound: 0,
         sum_other_doc_count: 0,
         buckets: [
           {
             key: 'Okeechobee County Schools, Florida',
             doc_count: 552831,
-            groups: {
+            rows: {
               buckets: [
                 {
                   key_as_string: '2015-01-01T00:00:00.000Z',
@@ -89,7 +89,7 @@ let response = {
           {
             key: "Okeechobee County Sheriff's Office, Florida",
             doc_count: 11984,
-            groups: {
+            rows: {
               buckets: [
                 {
                   key_as_string: '2015-01-01T00:00:00.000Z',
@@ -153,7 +153,7 @@ let response = {
           {
             key: 'Okeechobee County Board of County Commissioners, Florida',
             doc_count: 5100,
-            groups: {
+            rows: {
               buckets: [
                 {
                   key_as_string: '2018-01-01T00:00:00.000Z',
@@ -193,7 +193,7 @@ let response = {
           {
             key: 'Okeechobee Soil And Water Conservation District, Florida',
             doc_count: 2983,
-            groups: {
+            rows: {
               buckets: [
                 {
                   key_as_string: '2015-01-01T00:00:00.000Z',
@@ -257,7 +257,7 @@ let response = {
           {
             key: 'Okeechobee County Clerk of the Circuit Court, Florida',
             doc_count: 1349,
-            groups: {
+            rows: {
               buckets: [
                 {
                   key_as_string: '2015-01-01T00:00:00.000Z',

--- a/test/example-types/metricGroups/pivotData/pivotResponse.js
+++ b/test/example-types/metricGroups/pivotData/pivotResponse.js
@@ -16,21 +16,21 @@ let pivotResponse = {
     hits: [],
   },
   aggregations: {
-    groups: {
+    rows: {
       doc_count_error_upper_bound: 11609804,
       sum_other_doc_count: 442825686,
       buckets: [
         {
           key: 'Texas',
           doc_count: 85720456,
-          groups: {
+          rows: {
             doc_count_error_upper_bound: 566241,
             sum_other_doc_count: 74749378,
             buckets: [
               {
                 key: 'UT Southwestern Medical Center, Texas',
                 doc_count: 2280465,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -74,7 +74,7 @@ let pivotResponse = {
               {
                 key: 'University of Texas MD Anderson Cancer Center, Texas',
                 doc_count: 1272132,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -118,7 +118,7 @@ let pivotResponse = {
               {
                 key: 'Northside Independent School District, Texas',
                 doc_count: 1209799,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -162,7 +162,7 @@ let pivotResponse = {
               {
                 key: 'Texas Health and Human Services Commission, Texas',
                 doc_count: 1026638,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -206,7 +206,7 @@ let pivotResponse = {
               {
                 key: 'Houston ISD, Texas',
                 doc_count: 1011486,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -250,7 +250,7 @@ let pivotResponse = {
               {
                 key: 'Garland Independent School District, Texas',
                 doc_count: 859890,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -294,7 +294,7 @@ let pivotResponse = {
               {
                 key: 'City of San Antonio, Texas',
                 doc_count: 844879,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -338,7 +338,7 @@ let pivotResponse = {
               {
                 key: 'Katy Independent School District, Texas',
                 doc_count: 835188,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -382,7 +382,7 @@ let pivotResponse = {
               {
                 key: 'Dallas ISD, Texas',
                 doc_count: 831819,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -426,7 +426,7 @@ let pivotResponse = {
               {
                 key: 'McAllen Independent School District (ISD), Texas',
                 doc_count: 798782,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -473,14 +473,14 @@ let pivotResponse = {
         {
           key: 'Ohio',
           doc_count: 69508750,
-          groups: {
+          rows: {
             doc_count_error_upper_bound: 310692,
             sum_other_doc_count: 58439970,
             buckets: [
               {
                 key: 'Ohio State University, Ohio',
                 doc_count: 4952263,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -524,7 +524,7 @@ let pivotResponse = {
               {
                 key: 'Greene County Court of Commons Pleas, Ohio',
                 doc_count: 1078624,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -568,7 +568,7 @@ let pivotResponse = {
               {
                 key: 'Lakota Local School District, Ohio',
                 doc_count: 778589,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -612,7 +612,7 @@ let pivotResponse = {
               {
                 key: 'Westerville City School District, Ohio',
                 doc_count: 765253,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -656,7 +656,7 @@ let pivotResponse = {
               {
                 key: 'Greene County, Ohio',
                 doc_count: 758371,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -700,7 +700,7 @@ let pivotResponse = {
               {
                 key: 'City of Columbus, Ohio',
                 doc_count: 596072,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -744,7 +744,7 @@ let pivotResponse = {
               {
                 key: 'Dayton City School District, Ohio',
                 doc_count: 594213,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -788,7 +788,7 @@ let pivotResponse = {
               {
                 key: 'Sylvania City School District, Ohio',
                 doc_count: 536559,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -832,7 +832,7 @@ let pivotResponse = {
               {
                 key: 'Stark County, Ohio',
                 doc_count: 527452,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -876,7 +876,7 @@ let pivotResponse = {
               {
                 key: 'Cleveland Metropolitan School District, Ohio',
                 doc_count: 481384,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -923,14 +923,14 @@ let pivotResponse = {
         {
           key: 'California',
           doc_count: 64124722,
-          groups: {
+          rows: {
             doc_count_error_upper_bound: 239292,
             sum_other_doc_count: 39367553,
             buckets: [
               {
                 key: 'County of Los Angeles, California',
                 doc_count: 10888355,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -974,7 +974,7 @@ let pivotResponse = {
               {
                 key: 'County of Santa Clara, California',
                 doc_count: 3414238,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -1018,7 +1018,7 @@ let pivotResponse = {
               {
                 key: 'City of Los Angeles, California',
                 doc_count: 2878536,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -1062,7 +1062,7 @@ let pivotResponse = {
               {
                 key: 'El Camino Hospital, California',
                 doc_count: 1781902,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -1106,7 +1106,7 @@ let pivotResponse = {
               {
                 key: 'Kaweah Delta Health Care District, California',
                 doc_count: 1601346,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -1150,7 +1150,7 @@ let pivotResponse = {
               {
                 key: 'Los Angeles Unified School District, California',
                 doc_count: 1574797,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -1194,7 +1194,7 @@ let pivotResponse = {
               {
                 key: 'Port of Los Angeles, California',
                 doc_count: 776067,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -1238,7 +1238,7 @@ let pivotResponse = {
               {
                 key: 'University of California - Santa Barbara, California',
                 doc_count: 746695,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -1283,7 +1283,7 @@ let pivotResponse = {
                 key:
                   'California Department of Corrections and Rehabilitation, California',
                 doc_count: 583087,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -1327,7 +1327,7 @@ let pivotResponse = {
               {
                 key: 'San Diego Unified School District, California',
                 doc_count: 512146,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -1374,7 +1374,7 @@ let pivotResponse = {
         {
           key: 'Virginia',
           doc_count: 44472457,
-          groups: {
+          rows: {
             doc_count_error_upper_bound: 119005,
             sum_other_doc_count: 10007149,
             buckets: [
@@ -1382,7 +1382,7 @@ let pivotResponse = {
                 key:
                   'Department of Defense: Defense Logistics Agency, Virginia',
                 doc_count: 20473438,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -1427,7 +1427,7 @@ let pivotResponse = {
                 key:
                   'Department of Defense: Defense Logistics Agency - Central, Virginia',
                 doc_count: 5141775,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -1471,7 +1471,7 @@ let pivotResponse = {
               {
                 key: 'City of Richmond, Virginia',
                 doc_count: 2728830,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -1516,7 +1516,7 @@ let pivotResponse = {
                 key:
                   'Defense Contract Management Agency (DCMA) - DLA, Virginia',
                 doc_count: 2435845,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -1560,7 +1560,7 @@ let pivotResponse = {
               {
                 key: 'University of Virginia, Virginia',
                 doc_count: 1221571,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -1605,7 +1605,7 @@ let pivotResponse = {
                 key:
                   'Virginia Polytechnic Institute And State University, Virginia',
                 doc_count: 702118,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -1649,7 +1649,7 @@ let pivotResponse = {
               {
                 key: 'Fairfax County Schools, Virginia',
                 doc_count: 567798,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -1693,7 +1693,7 @@ let pivotResponse = {
               {
                 key: 'Virginia Commonwealth University, Virginia',
                 doc_count: 462921,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -1737,7 +1737,7 @@ let pivotResponse = {
               {
                 key: 'Chesterfield County, Virginia',
                 doc_count: 379948,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -1781,7 +1781,7 @@ let pivotResponse = {
               {
                 key: 'Virginia Department of Transportation, Virginia',
                 doc_count: 351064,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -1828,14 +1828,14 @@ let pivotResponse = {
         {
           key: 'New York',
           doc_count: 39288383,
-          groups: {
+          rows: {
             doc_count_error_upper_bound: 170147,
             sum_other_doc_count: 29196807,
             buckets: [
               {
                 key: 'City of New York, New York',
                 doc_count: 1713517,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -1879,7 +1879,7 @@ let pivotResponse = {
               {
                 key: 'New York City Department of Finance, New York',
                 doc_count: 1690325,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -1923,7 +1923,7 @@ let pivotResponse = {
               {
                 key: 'New York City Council, New York',
                 doc_count: 1678148,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -1967,7 +1967,7 @@ let pivotResponse = {
               {
                 key: 'State University of New York SUNY Buffalo, New York',
                 doc_count: 1676457,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -2011,7 +2011,7 @@ let pivotResponse = {
               {
                 key: 'SUNY Upstate Medical University, New York',
                 doc_count: 835746,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -2055,7 +2055,7 @@ let pivotResponse = {
               {
                 key: 'New York City School Construction Authority, New York',
                 doc_count: 644906,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -2099,7 +2099,7 @@ let pivotResponse = {
               {
                 key: 'New York City Department of Education, New York',
                 doc_count: 644795,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -2143,7 +2143,7 @@ let pivotResponse = {
               {
                 key: 'NYC Department of Environmental Protection, New York',
                 doc_count: 433782,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -2187,7 +2187,7 @@ let pivotResponse = {
               {
                 key: 'New York City Transit Authority, New York',
                 doc_count: 407118,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -2231,7 +2231,7 @@ let pivotResponse = {
               {
                 key: "New York City Comptroller's Office, New York",
                 doc_count: 366782,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -2278,14 +2278,14 @@ let pivotResponse = {
         {
           key: 'Florida',
           doc_count: 39206506,
-          groups: {
+          rows: {
             doc_count_error_upper_bound: 264500,
             sum_other_doc_count: 24714887,
             buckets: [
               {
                 key: 'Jackson Health System, Florida',
                 doc_count: 7633238,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -2329,7 +2329,7 @@ let pivotResponse = {
               {
                 key: 'University of Florida, Florida',
                 doc_count: 1350903,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -2373,7 +2373,7 @@ let pivotResponse = {
               {
                 key: 'Broward County Public Schools, Florida',
                 doc_count: 1158074,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -2417,7 +2417,7 @@ let pivotResponse = {
               {
                 key: 'Florida Department of Health, Florida',
                 doc_count: 821457,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -2461,7 +2461,7 @@ let pivotResponse = {
               {
                 key: 'City of Milton, Florida',
                 doc_count: 732396,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -2505,7 +2505,7 @@ let pivotResponse = {
               {
                 key: 'Halifax Medical Center, Florida',
                 doc_count: 623926,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -2549,7 +2549,7 @@ let pivotResponse = {
               {
                 key: 'Nassau County School District, Florida',
                 doc_count: 567478,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -2593,7 +2593,7 @@ let pivotResponse = {
               {
                 key: 'Okeechobee County Schools, Florida',
                 doc_count: 550406,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -2637,7 +2637,7 @@ let pivotResponse = {
               {
                 key: 'Hillsborough County Public School Board, Florida',
                 doc_count: 529912,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -2681,7 +2681,7 @@ let pivotResponse = {
               {
                 key: 'Florida Department of Corrections, Florida',
                 doc_count: 523829,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -2728,14 +2728,14 @@ let pivotResponse = {
         {
           key: 'Illinois',
           doc_count: 37538822,
-          groups: {
+          rows: {
             doc_count_error_upper_bound: 111550,
             sum_other_doc_count: 31185933,
             buckets: [
               {
                 key: 'Chicago Public Schools, Illinois',
                 doc_count: 2526461,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -2780,7 +2780,7 @@ let pivotResponse = {
                 key:
                   'University of Illinois at Chicago, Urbana-Champaign, and Springfield, Illinois',
                 doc_count: 826448,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -2824,7 +2824,7 @@ let pivotResponse = {
               {
                 key: 'Illinois State Department Of Transportation, Illinois',
                 doc_count: 792432,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -2868,7 +2868,7 @@ let pivotResponse = {
               {
                 key: 'Cook County, Illinois',
                 doc_count: 715188,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -2912,7 +2912,7 @@ let pivotResponse = {
               {
                 key: 'Metra Commuter Rail Board, Illinois',
                 doc_count: 346144,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -2956,7 +2956,7 @@ let pivotResponse = {
               {
                 key: 'Rockford School District No. 205, Illinois',
                 doc_count: 293504,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -3001,7 +3001,7 @@ let pivotResponse = {
                 key:
                   'Kane County Community Unit School District No. 300, Illinois',
                 doc_count: 280988,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -3045,7 +3045,7 @@ let pivotResponse = {
               {
                 key: 'Illinois Department of Corrections, Illinois',
                 doc_count: 230931,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -3089,7 +3089,7 @@ let pivotResponse = {
               {
                 key: 'Cicero Public School District No. 99, Illinois',
                 doc_count: 179302,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -3133,7 +3133,7 @@ let pivotResponse = {
               {
                 key: 'Winnebago County, Illinois',
                 doc_count: 161491,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -3180,14 +3180,14 @@ let pivotResponse = {
         {
           key: 'Michigan',
           doc_count: 30984705,
-          groups: {
+          rows: {
             doc_count_error_upper_bound: 87337,
             sum_other_doc_count: 14320143,
             buckets: [
               {
                 key: 'University of Michigan at Ann Arbor, Michigan',
                 doc_count: 13615474,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -3231,7 +3231,7 @@ let pivotResponse = {
               {
                 key: 'County of Macomb, Michigan',
                 doc_count: 801980,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -3275,7 +3275,7 @@ let pivotResponse = {
               {
                 key: 'Michigan State University, Michigan',
                 doc_count: 745099,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -3319,7 +3319,7 @@ let pivotResponse = {
               {
                 key: 'Wayne State University, Michigan',
                 doc_count: 380636,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -3363,7 +3363,7 @@ let pivotResponse = {
               {
                 key: 'City of Detroit, Michigan',
                 doc_count: 252994,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -3407,7 +3407,7 @@ let pivotResponse = {
               {
                 key: 'Michigan State Department Of Corrections, Michigan',
                 doc_count: 210364,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -3451,7 +3451,7 @@ let pivotResponse = {
               {
                 key: 'City of Kalamazoo, Michigan',
                 doc_count: 195170,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -3495,7 +3495,7 @@ let pivotResponse = {
               {
                 key: 'Washtenaw County, Michigan',
                 doc_count: 177396,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -3540,7 +3540,7 @@ let pivotResponse = {
                 key:
                   'Michigan State Department Of Health & Human Services, Michigan',
                 doc_count: 149338,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -3584,7 +3584,7 @@ let pivotResponse = {
               {
                 key: 'Michigan State Department Of Natural Resources, Michigan',
                 doc_count: 136111,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -3631,14 +3631,14 @@ let pivotResponse = {
         {
           key: 'New Jersey',
           doc_count: 29082460,
-          groups: {
+          rows: {
             doc_count_error_upper_bound: 138157,
             sum_other_doc_count: 26528043,
             buckets: [
               {
                 key: 'Newark Public Schools, New Jersey',
                 doc_count: 349082,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -3682,7 +3682,7 @@ let pivotResponse = {
               {
                 key: 'Monmouth County, New Jersey',
                 doc_count: 303493,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -3726,7 +3726,7 @@ let pivotResponse = {
               {
                 key: 'County of Morris, New Jersey',
                 doc_count: 290330,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -3770,7 +3770,7 @@ let pivotResponse = {
               {
                 key: 'Hudson County, New Jersey',
                 doc_count: 272180,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -3814,7 +3814,7 @@ let pivotResponse = {
               {
                 key: 'Hackensack Public Schools, New Jersey',
                 doc_count: 267957,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -3858,7 +3858,7 @@ let pivotResponse = {
               {
                 key: 'Brick Township Public Schools, New Jersey',
                 doc_count: 248415,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -3902,7 +3902,7 @@ let pivotResponse = {
               {
                 key: 'Deptford Township Schools, New Jersey',
                 doc_count: 213910,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -3946,7 +3946,7 @@ let pivotResponse = {
               {
                 key: 'New Jersey Turnpike Authority, New Jersey',
                 doc_count: 210273,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -3990,7 +3990,7 @@ let pivotResponse = {
               {
                 key: 'New Jersey Transit Corporation, New Jersey',
                 doc_count: 203853,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -4034,7 +4034,7 @@ let pivotResponse = {
               {
                 key: 'Rowan University, New Jersey',
                 doc_count: 194924,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -4081,14 +4081,14 @@ let pivotResponse = {
         {
           key: 'Washington',
           doc_count: 27410983,
-          groups: {
+          rows: {
             doc_count_error_upper_bound: 149568,
             sum_other_doc_count: 21288180,
             buckets: [
               {
                 key: 'University of Washington Medical Center, Washington',
                 doc_count: 1655206,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -4132,7 +4132,7 @@ let pivotResponse = {
               {
                 key: 'University of Washington, Washington',
                 doc_count: 1177600,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -4176,7 +4176,7 @@ let pivotResponse = {
               {
                 key: 'King County, Washington',
                 doc_count: 992466,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -4220,7 +4220,7 @@ let pivotResponse = {
               {
                 key: 'Mukilteo School District, Washington',
                 doc_count: 565947,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -4264,7 +4264,7 @@ let pivotResponse = {
               {
                 key: 'City of Tacoma, Washington',
                 doc_count: 381463,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -4308,7 +4308,7 @@ let pivotResponse = {
               {
                 key: 'City of Omak, Washington',
                 doc_count: 306668,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -4352,7 +4352,7 @@ let pivotResponse = {
               {
                 key: 'City of Selah, Washington',
                 doc_count: 288571,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -4396,7 +4396,7 @@ let pivotResponse = {
               {
                 key: 'Pasco School District, Washington',
                 doc_count: 268552,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -4440,7 +4440,7 @@ let pivotResponse = {
               {
                 key: 'Seattle School District 1, Washington',
                 doc_count: 251026,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',
@@ -4484,7 +4484,7 @@ let pivotResponse = {
               {
                 key: 'City of Seattle, Washington',
                 doc_count: 235304,
-                groups: {
+                rows: {
                   buckets: [
                     {
                       key: '0.0-500.0',


### PR DESCRIPTION
* [x] Pivot node: renamed `groups` to `rows`
* [x] Deprecating `flatten` flag as it was outdated, not used anywhere and not supporting columns
