### PR TITLE
feat: create tagsQueryGroupStats type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # 1.15.0
+* [pivot] Create new `tagsQueryGroupStats` type
+
+# 1.15.0
 * [pivot] Renaming groups to rows and deprecating the flatten flag
 
 # 1.14.2

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ We have a few new nodes of the form xGroupStats, where `x` is a grouping (bucket
 | Name            | Type                            | Default           | Description |
 | ----            | ----                            | -------           | ----------- |
 | `groupField`         | string                          | None, *required*  | The field to group by |
-| `statField`         | string                          | None  | The field to calculate stats for |
+| `statsField`         | string                          | None  | The field to calculate stats for |
 | `stats`        | [string]                   | ['sum', 'min', 'max', 'sum']                | Which stats to include, can be avg, min, max, sum, or any of the other metrics supported by elasticsearch. |
 
 Here's a kitchen example, with sections for the various types along with explanations for the more mongo focused developer:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/filters/tagsQuery.js
+++ b/src/example-types/filters/tagsQuery.js
@@ -81,9 +81,9 @@ let filter = ({ tags, join, field, exact }) => ({
   },
 })
 
-let buildResultQuery = node => ({
+let buildResultQuery = (node, children = {}, groupsKey = 'tags') => ({
   aggs: {
-    tags: {
+    [groupsKey]: {
       filters: {
         filters: F.arrayToObject(
           _.get('word'),
@@ -92,6 +92,7 @@ let buildResultQuery = node => ({
         ),
       },
     },
+    ...children,
   },
 })
 

--- a/src/example-types/index.js
+++ b/src/example-types/index.js
@@ -26,6 +26,7 @@ module.exports = {
   numberRangesGroupStats: require('./metricGroups/numberRangesGroupStats'),
   numberIntervalGroupStats: require('./metricGroups/numberIntervalGroupStats'),
   fieldValuePartitionGroupStats: require('./metricGroups/fieldValuePartitionGroupStats'),
+  tagsQueryGroupStats: require('./metricGroups/tagsQueryGroupStats'),
 
   // Legacy (covered by metric groups)
   statistical: require('./legacy/statistical'),

--- a/src/example-types/metricGroups/tagsQueryGroupStats.js
+++ b/src/example-types/metricGroups/tagsQueryGroupStats.js
@@ -1,0 +1,7 @@
+let { groupStats } = require('./groupStatUtils')
+let { buildResultQuery, filter } = require('../filters/tagsQuery')
+
+module.exports = {
+  ...groupStats(buildResultQuery),
+  drilldown: filter,
+}

--- a/test/example-types/metricGroups/pivot.js
+++ b/test/example-types/metricGroups/pivot.js
@@ -714,6 +714,56 @@ describe('pivot', () => {
     )
     expect(result).to.eql(expected)
   })
+  it('should buildQuery for tagsQuery', async () => {
+    let input = {
+      key: 'test',
+      type: 'pivot',
+      values: [{ type: 'sum', field: 'LineItem.TotalPrice' }],
+      rows: [
+        {
+          type: 'tagsQuery',
+          field: 'Organization.Name',
+          tags: [{ word: 'test' }],
+        },
+      ],
+    }
+    let expected = {
+      aggs: {
+        rows: {
+          filters: {
+            filters: {
+              test: {
+                query_string: {
+                  query: 'test',
+                  default_operator: 'AND',
+                  default_field: 'Organization.Name',
+                },
+              },
+            },
+          },
+        },
+        aggs: {
+          'pivotMetric-sum-LineItem.TotalPrice': {
+            sum: {
+              field: 'LineItem.TotalPrice',
+            },
+          },
+        },
+        'pivotMetric-sum-LineItem.TotalPrice': {
+          sum: {
+            field: 'LineItem.TotalPrice',
+          },
+        },
+      },
+      track_total_hits: true,
+    }
+    let result = await buildQuery(
+      input,
+      testSchemas(['Vendor.City']),
+      () => {} // getStats(search) -> stats(field, statsArray)
+    )
+    expect(result).to.eql(expected)
+  })
   it('should buildQuery with more types', async () => {
     let input = {
       key: 'test',

--- a/test/example-types/metricGroups/pivot.js
+++ b/test/example-types/metricGroups/pivot.js
@@ -759,7 +759,7 @@ describe('pivot', () => {
     }
     let result = await buildQuery(
       input,
-      testSchemas(['Vendor.City']),
+      testSchemas(['Organization.Name']),
       () => {} // getStats(search) -> stats(field, statsArray)
     )
     expect(result).to.eql(expected)

--- a/test/example-types/metricGroups/tagsQueryGroupStats.js
+++ b/test/example-types/metricGroups/tagsQueryGroupStats.js
@@ -1,0 +1,60 @@
+let {
+  buildQuery,
+  // buildGroupQuery,
+} = require('../../../src/example-types/metricGroups/tagsQueryGroupStats')
+let { expect } = require('chai')
+let { testSchema } = require('../testUtils')
+
+describe('tagsQueryGroupStats', () => {
+  it('should buildQuery', () => {
+    let result = buildQuery(
+      {
+        key: 'test',
+        type: 'tagsQueryGroupStats',
+        groupField: 'Organization.Name',
+        statsField: 'LineItem.TotalPrice',
+        tags: [{ word: 'test' }],
+      },
+      testSchema('Organization.Name')
+    )
+    expect(result).to.eql({
+      aggs: {
+        groups: {
+          filters: {
+            filters: {
+              test: {
+                query_string: {
+                  default_field: 'Organization.Name',
+                  default_operator: 'AND',
+                  query: 'test',
+                },
+              },
+            },
+          },
+        },
+        aggs: {
+          min: {
+            min: {
+              field: 'LineItem.TotalPrice',
+            },
+          },
+          max: {
+            max: {
+              field: 'LineItem.TotalPrice',
+            },
+          },
+          avg: {
+            avg: {
+              field: 'LineItem.TotalPrice',
+            },
+          },
+          sum: {
+            sum: {
+              field: 'LineItem.TotalPrice',
+            },
+          },
+        },
+      },
+    })
+  })
+})

--- a/test/example-types/metricGroups/tagsQueryGroupStats.js
+++ b/test/example-types/metricGroups/tagsQueryGroupStats.js
@@ -33,26 +33,10 @@ describe('tagsQueryGroupStats', () => {
           },
         },
         aggs: {
-          min: {
-            min: {
-              field: 'LineItem.TotalPrice',
-            },
-          },
-          max: {
-            max: {
-              field: 'LineItem.TotalPrice',
-            },
-          },
-          avg: {
-            avg: {
-              field: 'LineItem.TotalPrice',
-            },
-          },
-          sum: {
-            sum: {
-              field: 'LineItem.TotalPrice',
-            },
-          },
+          min: { min: { field: 'LineItem.TotalPrice' } },
+          max: { max: { field: 'LineItem.TotalPrice' } },
+          avg: { avg: { field: 'LineItem.TotalPrice' } },
+          sum: { sum: { field: 'LineItem.TotalPrice' } },
         },
       },
     })

--- a/test/types.js
+++ b/test/types.js
@@ -21,6 +21,7 @@ describe('All Example Types', function() {
       'numberRangesGroupStats',
       'percentilesGroupStats',
       'fieldValuePartitionGroupStats',
+      'tagsQueryGroupStats',
       'matchStats',
       'number',
       'query',


### PR DESCRIPTION
- Create `tagsQueryGroupStats` type for use with pivot filters
- Allow additional parameters for `buildGroupQuery` on the `tagsQuery` filter type
- Add tests for both cases