### PR TITLE
Support drilldowns with additional fields (multi-term aggregation) for `fieldValuesGroupStats` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.16.1
+* [pivot] Support drilldowns with additional fields (multi-term aggregation) for `fieldValuesGroupStats` type
+
 # 1.15.0
 * [pivot] Create new `tagsQueryGroupStats` type
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,11 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "contexture-elasticsearch",
-      "version": "1.14.2",
+      "version": "1.16.1",
       "license": "MIT",
       "dependencies": {
         "@elastic/datemath": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/metricGroups/fieldValuesGroupStats.js
+++ b/src/example-types/metricGroups/fieldValuesGroupStats.js
@@ -1,5 +1,4 @@
 let _ = require('lodash/fp')
-let F = require('futil')
 let { buildRegexQueryForWords } = require('../../utils/regex')
 let { getField } = require('../../utils/fields')
 let { groupStats } = require('./groupStatUtils')

--- a/src/example-types/metricGroups/fieldValuesGroupStats.js
+++ b/src/example-types/metricGroups/fieldValuesGroupStats.js
@@ -10,22 +10,13 @@ let getSortField = field => {
   return field
 }
 
-let drilldown = ({ field, drilldown, additionalFields }, schema) =>
+let drilldown = ({ field, drilldown, additionalFields = [] }, schema) =>
   // value is a pipe-delimited list of values when drilldown is using additional fields (multi-term aggregation)
-  _.flow(_.split('|'), ([fieldValue, ...additionalFieldValues]) => [
-    {
-      term: { [getField(schema, field)]: fieldValue },
-    },
-    // if there are additional fields, add a filter for each additional field value
-    ...(!_.isEmpty(additionalFields)
-      ? F.mapIndexed(
-          (fieldValue, field) => ({
-            term: { [getField(schema, field)]: fieldValue },
-          }),
-          _.zipObject(additionalFields, additionalFieldValues)
-        )
-      : []),
-  ])(drilldown)
+  _.zipWith(
+    (field, value) => ({ term: { [getField(schema, field)]: value } }),
+    [field, ...additionalFields],
+    _.split('|', drilldown),
+  )
 
 let buildGroupQuery = (node, children, groupingType, schema) => {
   let {

--- a/test/example-types/metricGroups/pivot.js
+++ b/test/example-types/metricGroups/pivot.js
@@ -304,15 +304,38 @@ describe('pivot', () => {
         },
       ],
     }
+    let inputMultiTermDrilldownLevel = {
+      key: 'test',
+      type: 'pivot',
+      values: [{ type: 'sum', field: 'LineItem.TotalPrice' }],
+      drilldown: ['Reno|NV', '0.0-500.0'],
+      rows: [
+        {
+          type: 'fieldValues',
+          field: 'Organization.Name',
+          additionalFields: ['Organization.State'],
+        },
+        {
+          type: 'numberRanges',
+          field: 'LineItem.TotalPrice',
+          ranges: [
+            { from: '0', to: '500' },
+            { from: '500', to: '10000' },
+          ],
+        },
+      ],
+    }
     let expectedTopLevel = {
       aggs: {
         pivotFilter: {
           filter: {
-            bool: { must: [{ term: { 'Organization.Name': 'Reno' } }] },
+            bool: {
+              must: [{ term: { 'Organization.Name.untouched': 'Reno' } }],
+            },
           },
           aggs: {
             rows: {
-              terms: { field: 'Organization.Name', size: 10 },
+              terms: { field: 'Organization.Name.untouched', size: 10 },
               aggs: {
                 'pivotMetric-sum-LineItem.TotalPrice': {
                   sum: { field: 'LineItem.TotalPrice' },
@@ -334,7 +357,7 @@ describe('pivot', () => {
           filter: {
             bool: {
               must: [
-                { term: { 'Organization.Name': 'Reno' } },
+                { term: { 'Organization.Name.untouched': 'Reno' } },
                 {
                   range: {
                     'LineItem.TotalPrice': {
@@ -348,7 +371,65 @@ describe('pivot', () => {
           },
           aggs: {
             rows: {
-              terms: { field: 'Organization.Name', size: 10 },
+              terms: { field: 'Organization.Name.untouched', size: 10 },
+              aggs: {
+                rows: {
+                  range: {
+                    field: 'LineItem.TotalPrice',
+                    ranges: [
+                      { from: '0', to: '500' },
+                      { from: '500', to: '10000' },
+                    ],
+                  },
+                  aggs: {
+                    'pivotMetric-sum-LineItem.TotalPrice': {
+                      sum: { field: 'LineItem.TotalPrice' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+    let expectedMultiTermDrilldown = {
+      track_total_hits: true,
+      aggs: {
+        pivotFilter: {
+          filter: {
+            bool: {
+              must: [
+                { term: { 'Organization.Name.untouched': 'Reno' } },
+                {
+                  term: {
+                    'Organization.State.untouched': 'NV',
+                  },
+                },
+                {
+                  range: {
+                    'LineItem.TotalPrice': {
+                      gte: '0.0',
+                      lt: '500.0',
+                    },
+                  },
+                },
+              ],
+            },
+          },
+          aggs: {
+            rows: {
+              multi_terms: {
+                size: 10,
+                terms: [
+                  {
+                    field: 'Organization.Name.untouched',
+                  },
+                  {
+                    field: 'Organization.State.untouched',
+                  },
+                ],
+              },
               aggs: {
                 rows: {
                   range: {
@@ -372,16 +453,22 @@ describe('pivot', () => {
     }
     let resultTopLevel = await buildQuery(
       inputTopLevel,
-      testSchemas(['Vendor.City']),
+      testSchemas(['Organization.Name']),
       () => {} // getStats(search) -> stats(field, statsArray)
     )
     expect(resultTopLevel).to.eql(expectedTopLevel)
     let resultDrilldownLevel = await buildQuery(
       inputDrilldownLevel,
-      testSchemas(['Vendor.City']),
+      testSchemas(['Organization.Name']),
       () => {} // getStats(search) -> stats(field, statsArray)
     )
     expect(resultDrilldownLevel).to.eql(expectedDrilldown)
+    let resultMultiTermDrilldownLevel = await buildQuery(
+      inputMultiTermDrilldownLevel,
+      testSchemas(['Organization.Name', 'Organization.State']),
+      () => {} // getStats(search) -> stats(field, statsArray)
+    )
+    expect(resultMultiTermDrilldownLevel).to.eql(expectedMultiTermDrilldown)
   })
   it('should buildQuery for fieldValues with drilldown and limited depth', async () => {
     let input = {


### PR DESCRIPTION
- Create filter for every field in `additionalFields` in fieldValuesGroupStats
- Modify pivot node to handle single node returning an array of drilldown filters
- Add testing