### PR TITLE
Root Row Expansion Handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.19.0
+* [pivot] - Make sure we are checking for a root row/column expansion where drilldown is empty. If root row expansion is found make sure it is in position after root column expansion, if not found add it after root column expansion
+
 # 1.18.0
 * [pivot] New `pagination` logic for `columns` and `rows` with `drilldown`, `skip`, `include` and `expanded`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
- Make sure we are checking for a root row/column expansion where drilldown is empty
- If root row expansion is found make sure it is in position after root column expansion, if not found add it after root column expansion