### PR TITLE
Throw a more informative error when processing mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
+# 1.19.3
+* Small tweak throwing more informative error.
+
 # 1.19.2
 * [pivot] fix drilldown for `dateRangesGroupStats` type
+
 # 1.19.1
 * [pivot] Fixing initialization for `expansions` array
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-elasticsearch",
-  "version": "1.19.2",
+  "version": "1.19.3",
   "description": "ElasticSearch Provider for Contexture",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
This will prevent the app from starting all together, this is simple to fix but somewhat difficult to identify, this simply makes it more obvious which index is having issue being processed.